### PR TITLE
Fix ha_get_automation to handle numeric IDs from UI-created automations

### DIFF
--- a/custom_components/config_mcp/tools/automations.py
+++ b/custom_components/config_mcp/tools/automations.py
@@ -75,7 +75,17 @@ async def get_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
     if component is None:
         raise ValueError(f"Automation '{automation_id}' not found")
 
+    # First try to get by entity_id
     entity = component.get_entity(entity_id)
+
+    # If not found and automation_id doesn't look like an entity_id, search by unique_id
+    # This handles numeric IDs from UI-created automations (e.g., "1765219976897")
+    if entity is None and not automation_id.startswith("automation."):
+        for ent in component.entities:
+            if ent.unique_id == automation_id:
+                entity = ent
+                break
+
     if entity is None:
         raise ValueError(f"Automation '{automation_id}' not found")
 

--- a/custom_components/config_mcp/views/automations.py
+++ b/custom_components/config_mcp/views/automations.py
@@ -489,6 +489,16 @@ class AutomationDetailView(HomeAssistantView):
         entity_id = self._get_entity_id(automation_id)
         entity = _get_automation_entity(hass, entity_id)
 
+        # If not found and automation_id doesn't look like an entity_id, search by unique_id
+        # This handles numeric IDs from UI-created automations (e.g., "1765219976897")
+        if entity is None and not automation_id.startswith("automation."):
+            component = get_automation_component(hass)
+            if component is not None:
+                for ent in component.entities:
+                    if ent.unique_id == automation_id:
+                        entity = ent
+                        break
+
         if entity is None:
             return self.json_message(
                 f"Automation '{automation_id}' not found",


### PR DESCRIPTION
Resolves #2

The ha_get_automation function and REST API endpoint now correctly handle numeric timestamp-based IDs (e.g., "1765219976897") returned by ha_list_automations for UI-created automations.

Previously, these numeric IDs would fail because they were being converted to entity_ids like "automation.1765219976897", which don't exist. The fix adds a fallback to search by unique_id when the entity_id lookup fails.

This maintains backward compatibility - all existing ID formats continue to work:
- Numeric IDs from UI automations: "1765219976897"
- UUID IDs from YAML automations: "e70d67d6b35843e6959d5963c89b6026"
- String IDs from YAML automations: "welcome_home"
- Full entity_ids: "automation.christmas_lights_off_after_sunrise"