### PR TITLE
Add comprehensive helper support (StorageCollection + all 17 Config Entry Flow types)

### DIFF
--- a/custom_components/config_mcp_test/__init__.py
+++ b/custom_components/config_mcp_test/__init__.py
@@ -93,8 +93,8 @@ from .views import (
     FloorListView,
     HelperDetailView,
     HelperListView,
-    TemplateHelperDetailView,
-    TemplateHelperListView,
+    ConfigEntryHelperDetailView,
+    ConfigEntryHelperListView,
     IntegrationDetailView,
     IntegrationListView,
     LabelDetailView,
@@ -500,7 +500,7 @@ def _register_views(hass: HomeAssistant, options: dict[str, Any]) -> None:
     if helpers_enabled and RESOURCE_HELPERS not in _REGISTERED_VIEWS:
         hass.http.register_view(HelperListView())
         hass.http.register_view(HelperDetailView())
-        hass.http.register_view(TemplateHelperListView())
-        hass.http.register_view(TemplateHelperDetailView())
+        hass.http.register_view(ConfigEntryHelperListView())
+        hass.http.register_view(ConfigEntryHelperDetailView())
         _REGISTERED_VIEWS.add(RESOURCE_HELPERS)
         _LOGGER.info("Registered helper API endpoints at /api/config_mcp/helpers and /api/config_mcp/template_helpers")

--- a/custom_components/config_mcp_test/__init__.py
+++ b/custom_components/config_mcp_test/__init__.py
@@ -93,6 +93,8 @@ from .views import (
     FloorListView,
     HelperDetailView,
     HelperListView,
+    TemplateHelperDetailView,
+    TemplateHelperListView,
     IntegrationDetailView,
     IntegrationListView,
     LabelDetailView,
@@ -498,5 +500,7 @@ def _register_views(hass: HomeAssistant, options: dict[str, Any]) -> None:
     if helpers_enabled and RESOURCE_HELPERS not in _REGISTERED_VIEWS:
         hass.http.register_view(HelperListView())
         hass.http.register_view(HelperDetailView())
+        hass.http.register_view(TemplateHelperListView())
+        hass.http.register_view(TemplateHelperDetailView())
         _REGISTERED_VIEWS.add(RESOURCE_HELPERS)
-        _LOGGER.info("Registered helper API endpoints at /api/config_mcp/helpers")
+        _LOGGER.info("Registered helper API endpoints at /api/config_mcp/helpers and /api/config_mcp/template_helpers")

--- a/custom_components/config_mcp_test/const.py
+++ b/custom_components/config_mcp_test/const.py
@@ -118,6 +118,27 @@ HELPER_DOMAINS = [
     "schedule",
 ]
 
+# Config Entry Flow helper domains (managed via Config Entry flows)
+CONFIG_ENTRY_HELPER_DOMAINS = [
+    "derivative",
+    "filter",
+    "generic_hygrostat",
+    "generic_thermostat",
+    "group",
+    "history_stats",
+    "integration",
+    "min_max",
+    "mold_indicator",
+    "random",
+    "statistics",
+    "switch_as_x",
+    "template",
+    "threshold",
+    "tod",
+    "trend",
+    "utility_meter",
+]
+
 # MCP Server configuration key
 CONF_MCP_SERVER = "mcp_server"
 CONF_MCP_OAUTH_ENABLED = "mcp_oauth_enabled"
@@ -189,7 +210,7 @@ API_BASE_PATH_AUTOMATIONS = "/api/config_mcp/automations"
 API_BASE_PATH_SCENES = "/api/config_mcp/scenes"
 API_BASE_PATH_SCRIPTS = "/api/config_mcp/scripts"
 API_BASE_PATH_HELPERS = "/api/config_mcp/helpers"
-API_BASE_PATH_TEMPLATE_HELPERS = "/api/config_mcp/template_helpers"
+API_BASE_PATH_CONFIG_ENTRY_HELPERS = "/api/config_mcp/config_entry_helpers"
 
 # Discovery API paths (read-only)
 API_BASE_PATH_ENTITIES = "/api/config_mcp/entities"

--- a/custom_components/config_mcp_test/const.py
+++ b/custom_components/config_mcp_test/const.py
@@ -105,15 +105,17 @@ DISCOVERY_RESOURCES = [
     RESOURCE_SERVICES,
 ]
 
-# Helper domains (input_* helpers and utility helpers)
+# Helper domains (StorageCollection-based helpers with WebSocket CRUD)
 HELPER_DOMAINS = [
     "input_boolean",
+    "input_button",
     "input_number",
     "input_text",
     "input_select",
     "input_datetime",
     "counter",
     "timer",
+    "schedule",
 ]
 
 # MCP Server configuration key
@@ -187,6 +189,7 @@ API_BASE_PATH_AUTOMATIONS = "/api/config_mcp/automations"
 API_BASE_PATH_SCENES = "/api/config_mcp/scenes"
 API_BASE_PATH_SCRIPTS = "/api/config_mcp/scripts"
 API_BASE_PATH_HELPERS = "/api/config_mcp/helpers"
+API_BASE_PATH_TEMPLATE_HELPERS = "/api/config_mcp/template_helpers"
 
 # Discovery API paths (read-only)
 API_BASE_PATH_ENTITIES = "/api/config_mcp/entities"

--- a/custom_components/config_mcp_test/manifest.json
+++ b/custom_components/config_mcp_test/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "config_mcp_test",
   "name": "Configuration MCP Server (Test)",
-  "version": "1.2.1",
+  "version": "1.4.4",
   "documentation": "https://github.com/jeremiah-mitchell/hass-configuration-mcp",
   "dependencies": ["lovelace", "http"],
   "after_dependencies": ["hass_oidc_auth"],

--- a/custom_components/config_mcp_test/strings.json
+++ b/custom_components/config_mcp_test/strings.json
@@ -28,6 +28,7 @@
           "automations": "Automations",
           "scripts": "Scripts",
           "scenes": "Scenes",
+          "helpers": "Helpers",
           "categories": "Categories & Labels"
         }
       },
@@ -127,6 +128,22 @@
           "scenes_create": "Create new scenes",
           "scenes_update": "Update scene config and entities",
           "scenes_delete": "Delete scenes"
+        }
+      },
+      "helpers": {
+        "title": "Helpers",
+        "description": "Configure helper management for input_* helpers (input_boolean, input_number, input_text, input_select, input_datetime, counter, timer) and template-based helpers (template sensors, binary sensors, switches, etc.).\n\n**MCP Tools:** `ha_list_helpers`, `ha_create_helper`, `ha_update_helper`, `ha_delete_helper`, `ha_list_template_helpers`, `ha_create_template_helper`, `ha_update_template_helper`, `ha_delete_template_helper`\n**REST Endpoint:** `/api/config_mcp/helpers`",
+        "data": {
+          "helpers_read": "Read",
+          "helpers_create": "Create",
+          "helpers_update": "Update",
+          "helpers_delete": "Delete"
+        },
+        "data_description": {
+          "helpers_read": "List and get input_* helpers and template-based helpers",
+          "helpers_create": "Create new input_* helpers and template helpers (sensors, binary sensors, switches, etc.)",
+          "helpers_update": "Update helper configuration and settings",
+          "helpers_delete": "Delete helpers permanently"
         }
       },
       "categories": {

--- a/custom_components/config_mcp_test/tools/helpers.py
+++ b/custom_components/config_mcp_test/tools/helpers.py
@@ -72,8 +72,9 @@ async def _get_helpers_for_domain(hass: HomeAssistant, domain: str) -> list[dict
     """
     helpers = []
 
-    # Use Store API to read from .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
+    # Use Store API to read from .storage/{domain}
+    # HA helper integrations use STORAGE_KEY = DOMAIN (no 'core.' prefix)
+    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, domain)
     data = await store.async_load()
 
     if data is None:
@@ -109,7 +110,7 @@ async def _get_helper_by_id(
     """
     for domain in HELPER_DOMAINS:
         try:
-            store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
+            store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, domain)
             data = await store.async_load()
 
             if data is None:

--- a/custom_components/config_mcp_test/tools/helpers.py
+++ b/custom_components/config_mcp_test/tools/helpers.py
@@ -18,7 +18,9 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
 
 from ..mcp_registry import mcp_tool
-from ..const import HELPER_DOMAINS
+import voluptuous as vol
+
+from ..const import CONFIG_ENTRY_HELPER_DOMAINS, HELPER_DOMAINS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -920,72 +922,237 @@ async def delete_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
 
 
 # =============================================================================
-# Template Helper Tools (Config Entry Flow API)
+# Config Entry Helper Tools (Config Entry Flow API)
+# =============================================================================
+# These helpers use HA's Config Entry Flow for creation/management, unlike
+# StorageCollection helpers (input_boolean, counter, etc.). Includes template
+# sensors, groups, utility meters, derivatives, thermostats, and more.
+#
+# The flow follower dynamically inspects each flow step's voluptuous schema
+# and submits matching fields from the user's config dict, making it work
+# with any current or future config-entry-flow helper integration.
+
+# Domains that present a menu step requiring sub_type selection
+MENU_FLOW_DOMAINS = {"group", "template", "random"}
+
+
+def _extract_form_data(schema, config_data):
+    """Extract fields from config_data that match a voluptuous schema."""
+    if schema is None:
+        return {}
+
+    submit_data = {}
+    for key in schema.schema:
+        if isinstance(key, vol.Marker):
+            field_name = key.schema
+        else:
+            field_name = str(key)
+
+        if field_name in config_data:
+            submit_data[field_name] = config_data[field_name]
+
+    return submit_data
+
+
+async def _follow_config_flow(hass, domain, config_data, sub_type=None):
+    """Follow a config entry flow to create a helper, submitting matching fields.
+
+    Handles all flow patterns automatically:
+    - Direct form: init -> form -> create_entry
+    - Multi-step form: init -> form -> form -> ... -> create_entry
+    - Menu-first: init -> menu -> form -> create_entry
+    """
+    try:
+        result = await hass.config_entries.flow.async_init(
+            domain, context={"source": "user"}
+        )
+    except Exception as err:
+        raise ValueError(
+            f"Failed to initiate config flow for '{domain}': {err}. "
+            f"Ensure the '{domain}' integration is loaded."
+        ) from err
+
+    flow_id = result["flow_id"]
+
+    for _ in range(10):  # safety limit for multi-step flows
+        flow_type = result.get("type")
+
+        if flow_type == "create_entry":
+            return result
+
+        if flow_type == "abort":
+            raise ValueError(
+                f"Config flow aborted: {result.get('reason', 'unknown')}"
+            )
+
+        if flow_type == "menu":
+            if not sub_type:
+                menu_options = result.get("menu_options", [])
+                raise ValueError(
+                    f"Domain '{domain}' requires sub_type. "
+                    f"Available: {', '.join(menu_options)}"
+                )
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, {"next_step_id": sub_type}
+            )
+            sub_type = None  # Only use for first menu
+            continue
+
+        if flow_type == "form":
+            schema = result.get("data_schema")
+            submit_data = _extract_form_data(schema, config_data)
+            try:
+                result = await hass.config_entries.flow.async_configure(
+                    flow_id, submit_data
+                )
+            except Exception as err:
+                step_id = result.get("step_id", "unknown")
+                raise ValueError(
+                    f"Failed at flow step '{step_id}': {err}"
+                ) from err
+            continue
+
+        raise ValueError(f"Unexpected flow step type: {flow_type}")
+
+    raise ValueError("Config flow did not complete within expected steps")
+
+
+async def _follow_options_flow(hass, entry_id, update_data):
+    """Follow an options flow, merging current options with updates."""
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None:
+        raise ValueError(f"Config entry '{entry_id}' not found")
+
+    merged = {**dict(entry.options), **update_data}
+
+    try:
+        result = await hass.config_entries.options.async_init(entry_id)
+    except Exception as err:
+        raise ValueError(
+            f"Failed to start options flow for '{entry.title}': {err}"
+        ) from err
+
+    flow_id = result["flow_id"]
+
+    for _ in range(10):
+        flow_type = result.get("type")
+
+        if flow_type == "create_entry":
+            return result
+
+        if flow_type == "abort":
+            raise ValueError(
+                f"Options flow aborted: {result.get('reason', 'unknown')}"
+            )
+
+        if flow_type == "form":
+            schema = result.get("data_schema")
+            submit_data = _extract_form_data(schema, merged)
+            try:
+                result = await hass.config_entries.options.async_configure(
+                    flow_id, submit_data
+                )
+            except Exception as err:
+                step_id = result.get("step_id", "unknown")
+                raise ValueError(
+                    f"Failed at options step '{step_id}': {err}"
+                ) from err
+            continue
+
+        raise ValueError(f"Unexpected options flow type: {flow_type}")
+
+    raise ValueError("Options flow did not complete within expected steps")
+
+
+# =============================================================================
+# List Config Entry Helpers
 # =============================================================================
 
-# Template sub-types available for creation
-TEMPLATE_TYPES = [
-    "alarm_control_panel", "binary_sensor", "button", "cover",
-    "event", "fan", "image", "light", "lock", "number",
-    "select", "sensor", "switch", "update", "vacuum", "weather",
-]
-
-
 @mcp_tool(
-    name="ha_list_template_helpers",
+    name="ha_list_config_entry_helpers",
     description=(
-        "List all template-based helpers (template sensors, binary sensors, "
-        "switches, etc.) that are created via Config Entry flows. These are "
-        "distinct from input_* helpers. Returns entry_id, title, template_type, "
-        "and configuration for each template helper."
+        "List config-entry-flow-based helpers (template sensors, groups, utility "
+        "meters, derivatives, thermostats, etc.). These are distinct from "
+        "StorageCollection helpers (input_boolean, counter, timer, etc.).\n\n"
+        "Optionally filter by domain and/or sub_type. Returns entry_id, title, "
+        "domain, state, and configuration for each helper."
     ),
     schema={
         "type": "object",
         "properties": {
-            "template_type": {
+            "domain": {
                 "type": "string",
                 "description": (
-                    "Filter by template sub-type (e.g., 'sensor', 'binary_sensor', "
-                    "'switch'). If omitted, returns all template helpers."
+                    "Filter by integration domain. If omitted, lists helpers "
+                    "from all config-entry-flow domains."
                 ),
-                "enum": TEMPLATE_TYPES,
+                "enum": CONFIG_ENTRY_HELPER_DOMAINS,
+            },
+            "sub_type": {
+                "type": "string",
+                "description": (
+                    "Filter by sub-type within a domain (e.g., 'sensor' for "
+                    "template sensors, 'light' for light groups)"
+                ),
             },
         },
     },
     permission="helpers_read",
 )
-async def list_template_helpers(
+async def list_config_entry_helpers(
     hass: HomeAssistant, arguments: dict[str, Any]
 ) -> list[dict[str, Any]]:
-    """List all template-based helpers."""
-    type_filter = arguments.get("template_type")
-    entries = hass.config_entries.async_entries("template")
+    """List all config-entry-flow-based helpers."""
+    domain_filter = arguments.get("domain")
+    sub_type_filter = arguments.get("sub_type")
+
+    domains = [domain_filter] if domain_filter else CONFIG_ENTRY_HELPER_DOMAINS
 
     results = []
-    for entry in entries:
-        template_type = entry.options.get("template_type", "")
-        if type_filter and template_type != type_filter:
+    for domain in domains:
+        try:
+            entries = hass.config_entries.async_entries(domain)
+        except Exception:
             continue
 
-        results.append({
-            "entry_id": entry.entry_id,
-            "title": entry.title,
-            "domain": "template",
-            "template_type": template_type,
-            "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
-            "options": dict(entry.options),
-        })
+        for entry in entries:
+            if sub_type_filter:
+                entry_options = entry.options or {}
+                entry_sub_type = (
+                    entry_options.get("template_type")
+                    or entry_options.get("group_type")
+                    or entry_options.get("type")
+                    or ""
+                )
+                if entry_sub_type != sub_type_filter:
+                    continue
 
-    results.sort(key=lambda x: (x.get("template_type", ""), x.get("title", "").lower()))
+            results.append({
+                "entry_id": entry.entry_id,
+                "title": entry.title,
+                "domain": entry.domain,
+                "state": (
+                    entry.state.value
+                    if hasattr(entry.state, "value")
+                    else str(entry.state)
+                ),
+                "options": dict(entry.options) if entry.options else {},
+            })
+
+    results.sort(key=lambda x: (x["domain"], x.get("title", "").lower()))
     return results
 
 
+# =============================================================================
+# Get Config Entry Helper
+# =============================================================================
+
 @mcp_tool(
-    name="ha_get_template_helper",
+    name="ha_get_config_entry_helper",
     description=(
-        "Get full details for a specific template-based helper by its config "
-        "entry ID. Returns the entry configuration, options, template type, "
-        "and current state."
+        "Get full details for a specific config-entry-flow helper by its config "
+        "entry ID. Returns configuration, options, associated entities, and "
+        "current state."
     ),
     schema={
         "type": "object",
@@ -993,8 +1160,8 @@ async def list_template_helpers(
             "entry_id": {
                 "type": "string",
                 "description": (
-                    "The config entry ID of the template helper. "
-                    "Get this from ha_list_template_helpers."
+                    "The config entry ID. Get this from "
+                    "ha_list_config_entry_helpers."
                 ),
             },
         },
@@ -1002,36 +1169,37 @@ async def list_template_helpers(
     },
     permission="helpers_read",
 )
-async def get_template_helper(
+async def get_config_entry_helper(
     hass: HomeAssistant, arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Get a specific template-based helper by config entry ID."""
+    """Get a specific config-entry-flow helper."""
     entry_id = arguments["entry_id"]
 
     entry = hass.config_entries.async_get_entry(entry_id)
     if entry is None:
         raise ValueError(f"Config entry '{entry_id}' not found")
 
-    if entry.domain != "template":
+    if entry.domain not in CONFIG_ENTRY_HELPER_DOMAINS:
         raise ValueError(
-            f"Config entry '{entry_id}' is not a template helper "
+            f"Config entry '{entry_id}' is not a config-entry helper "
             f"(domain: {entry.domain})"
         )
-
-    template_type = entry.options.get("template_type", "")
 
     result: dict[str, Any] = {
         "entry_id": entry.entry_id,
         "title": entry.title,
-        "domain": "template",
-        "template_type": template_type,
-        "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
+        "domain": entry.domain,
+        "state": (
+            entry.state.value
+            if hasattr(entry.state, "value")
+            else str(entry.state)
+        ),
         "supports_options": entry.supports_options,
         "supports_unload": entry.supports_unload,
-        "options": dict(entry.options),
+        "options": dict(entry.options) if entry.options else {},
     }
 
-    # Find the entity associated with this config entry
+    # Find associated entities
     entity_registry = er.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_registry, entry_id)
     if entities:
@@ -1042,15 +1210,20 @@ async def get_template_helper(
                 "name": entity_entry.name or entity_entry.original_name,
                 "area_id": entity_entry.area_id,
                 "disabled": entity_entry.disabled_by is not None,
-                "labels": list(entity_entry.labels) if entity_entry.labels else [],
+                "labels": (
+                    list(entity_entry.labels) if entity_entry.labels else []
+                ),
             }
-            # Add current state
             state = hass.states.get(entity_entry.entity_id)
             if state:
                 entity_data["current_state"] = {
                     "state": state.state,
                     "attributes": dict(state.attributes),
-                    "last_changed": state.last_changed.isoformat() if state.last_changed else None,
+                    "last_changed": (
+                        state.last_changed.isoformat()
+                        if state.last_changed
+                        else None
+                    ),
                 }
             entity_entries.append(entity_data)
         result["entities"] = entity_entries
@@ -1058,160 +1231,150 @@ async def get_template_helper(
     return result
 
 
+# =============================================================================
+# Create Config Entry Helper
+# =============================================================================
+
+_CREATE_DESCRIPTION = (
+    "Create a config-entry-flow helper. The flow is followed automatically - "
+    "just provide domain, config fields, and sub_type if needed.\n\n"
+    "For menu-based domains (group, template, random), sub_type is required.\n\n"
+    "DOMAIN REFERENCE (* = required):\n\n"
+    "DIRECT FORM DOMAINS:\n"
+    "- derivative: name*, source* (entity_id), round_digits, "
+    "time_window (dict {hours/minutes/seconds}), unit_prefix (n|u|m|k|M|G|T|P), "
+    "unit_time (s|min|h|d)\n"
+    "- generic_hygrostat: name*, device_class* (humidifier|dehumidifier), "
+    "sensor* (humidity entity_id), humidifier* (switch/fan entity_id), "
+    "dry_tolerance*, wet_tolerance*\n"
+    "- integration: name*, source_sensor* (entity_id), "
+    "method (trapezoidal|left|right), round_digits, unit_prefix (k|M|G|T), "
+    "unit_time (s|min|h|d)\n"
+    "- min_max: name*, entity_ids* (list of entity_ids), "
+    "type* (min|max|mean|median|last|range|sum), round_digits\n"
+    "- mold_indicator: name*, indoor_temp* (entity_id), "
+    "indoor_humidity* (entity_id), outdoor_temp* (entity_id), "
+    "calibration_factor*\n"
+    "- switch_as_x: entity_id* (switch entity), "
+    "target_domain* (cover|fan|light|lock|siren|valve), invert\n"
+    "- threshold: name*, entity_id* (sensor), lower and/or upper "
+    "(at least one required), hysteresis\n"
+    "- tod: name*, after_time* (HH:MM:SS), before_time* (HH:MM:SS)\n"
+    "- utility_meter: name*, source_sensor* (entity_id), "
+    "meter_type* (none|quarter-hourly|hourly|daily|weekly|monthly|"
+    "bimonthly|quarterly|yearly), tariffs (list), net_consumption, "
+    "delta_values, periodically_resetting\n\n"
+    "MULTI-STEP FORM DOMAINS:\n"
+    "- filter: name*, entity_id*, filter_name* (lowpass|outlier|range|"
+    "throttle|time_sma|time_throttle), filter_window_size, filter_radius, "
+    "filter_precision\n"
+    "- generic_thermostat: name*, ac_mode* (bool), sensor* (temp entity_id), "
+    "heater* (switch/fan entity_id), cold_tolerance*, hot_tolerance*, "
+    "min_temp, max_temp\n"
+    "- history_stats: name*, entity_id*, type* (time|ratio|count), "
+    "state* (list of state strings)\n"
+    "- statistics: name*, entity_id*, state_characteristic* "
+    "(average_linear|count|mean|median|standard_deviation|sum|value_max|"
+    "value_min|variance|etc.)\n"
+    "- trend: name*, entity_id* (sensor), attribute, invert, max_samples, "
+    "min_samples, min_gradient, sample_duration\n\n"
+    "MENU DOMAINS (sub_type required):\n"
+    "- group: sub_type* (binary_sensor|cover|fan|light|lock|media_player|"
+    "sensor|switch|etc.), name*, entities* (list), hide_members, "
+    "all (bool, for binary_sensor/light/switch), "
+    "type (sensor: min|max|mean|median|sum)\n"
+    "- random: sub_type* (binary_sensor|sensor), name*, minimum, maximum, "
+    "device_class\n"
+    "- template: sub_type* (sensor|binary_sensor|switch|number|select|"
+    "button|cover|fan|light|lock|etc.), name*, state* (Jinja2), "
+    "unit_of_measurement, device_class, state_class, availability"
+)
+
+
 @mcp_tool(
-    name="ha_create_template_helper",
-    description=(
-        "Create a template-based helper (template sensor, binary sensor, switch, "
-        "etc.) using Home Assistant's Config Entry Flow API. This is a 3-step "
-        "process handled automatically.\n\n"
-        "Common template_type values: sensor, binary_sensor, switch, number, "
-        "select, button, light, cover, fan, lock, vacuum, weather.\n\n"
-        "The 'state' field is a Jinja2 template string, e.g.:\n"
-        "  '{{ states(\"sensor.temperature\") }}'\n"
-        "  '{{ is_state(\"binary_sensor.door\", \"on\") }}'\n\n"
-        "IMPORTANT: Optional enum fields (device_class, state_class) must be "
-        "omitted entirely if not needed — empty strings cause validation errors."
-    ),
+    name="ha_create_config_entry_helper",
+    description=_CREATE_DESCRIPTION,
     schema={
         "type": "object",
         "properties": {
-            "template_type": {
+            "domain": {
+                "type": "string",
+                "description": "The helper integration domain",
+                "enum": CONFIG_ENTRY_HELPER_DOMAINS,
+            },
+            "sub_type": {
                 "type": "string",
                 "description": (
-                    "The type of template helper to create. Common values: "
-                    "sensor, binary_sensor, switch, number, select, button, "
-                    "light, cover, fan, lock, vacuum, weather"
+                    "Sub-type for menu domains. Required for group "
+                    "(binary_sensor, cover, fan, light, lock, media_player, "
+                    "sensor, switch), template (sensor, binary_sensor, switch, "
+                    "number, etc.), and random (binary_sensor, sensor)."
                 ),
-                "enum": TEMPLATE_TYPES,
             },
-            "name": {
-                "type": "string",
-                "description": "Human-readable name for the template helper (required)",
-            },
-            "state": {
-                "type": "string",
+            "config": {
+                "type": "object",
                 "description": (
-                    "Jinja2 template for the entity state (required). "
-                    "Example: '{{ states(\"sensor.time\") }}'"
+                    "Configuration fields as key-value pairs. Required and "
+                    "optional fields depend on the domain - see tool description."
                 ),
-            },
-            "unit_of_measurement": {
-                "type": "string",
-                "description": "Unit of measurement (sensor only, optional)",
-            },
-            "device_class": {
-                "type": "string",
-                "description": (
-                    "Device class for the entity (optional). Must be a valid "
-                    "value for the template_type — omit if not needed."
-                ),
-            },
-            "state_class": {
-                "type": "string",
-                "description": (
-                    "State class (sensor only, optional). Valid values: "
-                    "measurement, measurement_angle, total, total_increasing. "
-                    "Omit if not needed."
-                ),
-            },
-            "availability": {
-                "type": "string",
-                "description": (
-                    "Jinja2 template for availability (optional). "
-                    "Should evaluate to true/false."
-                ),
-            },
-            "device_id": {
-                "type": "string",
-                "description": "Device to associate the helper with (optional)",
             },
         },
-        "required": ["template_type", "name", "state"],
+        "required": ["domain", "config"],
     },
     permission="helpers_create",
 )
-async def create_template_helper(
+async def create_config_entry_helper(
     hass: HomeAssistant, arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Create a template-based helper via Config Entry Flow."""
-    template_type = arguments["template_type"]
-    name = arguments["name"]
-    state = arguments["state"]
+    """Create a config-entry-flow helper."""
+    domain = arguments["domain"]
+    sub_type = arguments.get("sub_type")
+    config_data = arguments.get("config", {})
 
-    # Step 1: Initiate the config entry flow
-    try:
-        result = await hass.config_entries.flow.async_init(
-            "template", context={"source": "user"}
-        )
-    except Exception as err:
+    if domain not in CONFIG_ENTRY_HELPER_DOMAINS:
         raise ValueError(
-            f"Failed to initiate template config flow: {err}. "
-            f"Ensure the 'template' integration is loaded."
-        ) from err
-
-    flow_id = result["flow_id"]
-
-    # Step 2: Select the template sub-type
-    try:
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {"next_step_id": template_type}
+            f"Invalid domain '{domain}'. Valid domains: "
+            f"{', '.join(CONFIG_ENTRY_HELPER_DOMAINS)}"
         )
-    except Exception as err:
+
+    if domain in MENU_FLOW_DOMAINS and not sub_type:
         raise ValueError(
-            f"Failed to select template type '{template_type}': {err}"
-        ) from err
-
-    # Step 3: Submit the configuration
-    config_data: dict[str, Any] = {
-        "name": name,
-        "state": state,
-    }
-
-    # Add optional fields only if provided (empty strings cause validation errors)
-    for field in ("unit_of_measurement", "device_class", "state_class",
-                  "availability", "device_id"):
-        if field in arguments and arguments[field]:
-            config_data[field] = arguments[field]
-
-    try:
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, config_data
+            f"Domain '{domain}' requires sub_type parameter"
         )
-    except Exception as err:
-        raise ValueError(
-            f"Failed to create template helper: {err}"
-        ) from err
 
-    if result.get("type") != "create_entry":
-        raise ValueError(
-            f"Unexpected flow result type: {result.get('type')}. "
-            f"Expected 'create_entry'. Result: {result}"
-        )
+    result = await _follow_config_flow(hass, domain, config_data, sub_type)
 
     entry_result = result.get("result", {})
     entry_id = (
         entry_result.entry_id
         if hasattr(entry_result, "entry_id")
-        else entry_result.get("entry_id")
+        else entry_result.get("entry_id") if isinstance(entry_result, dict)
+        else str(entry_result)
     )
 
     return {
         "entry_id": entry_id,
-        "title": result.get("title", name),
-        "domain": "template",
-        "template_type": template_type,
+        "title": result.get("title", config_data.get("name", "")),
+        "domain": domain,
+        "sub_type": sub_type,
         "options": result.get("options", config_data),
-        "message": f"Template {template_type} helper '{name}' created",
+        "message": f"{domain} helper created",
     }
 
 
+# =============================================================================
+# Update Config Entry Helper
+# =============================================================================
+
 @mcp_tool(
-    name="ha_update_template_helper",
+    name="ha_update_config_entry_helper",
     description=(
-        "Update a template-based helper's configuration via the Options Flow API. "
-        "Use ha_list_template_helpers to find entry IDs and current options.\n\n"
+        "Update a config-entry-flow helper via its Options Flow. Provide the "
+        "entry_id and the fields to update. Current options are merged with "
+        "updates automatically.\n\n"
+        "Use ha_list_config_entry_helpers to find entry IDs and current options.\n\n"
         "IMPORTANT: Optional enum fields (device_class, state_class) must be "
-        "omitted entirely if not needed — empty strings cause validation errors."
+        "omitted entirely if not needed - empty strings may cause validation errors."
     ),
     schema={
         "type": "object",
@@ -1219,115 +1382,73 @@ async def create_template_helper(
             "entry_id": {
                 "type": "string",
                 "description": (
-                    "The config entry ID of the template helper to update. "
-                    "Get this from ha_list_template_helpers."
+                    "The config entry ID to update. Get this from "
+                    "ha_list_config_entry_helpers."
                 ),
             },
-            "name": {
-                "type": "string",
-                "description": "New name for the template helper",
-            },
-            "state": {
-                "type": "string",
+            "updates": {
+                "type": "object",
                 "description": (
-                    "New Jinja2 template for the entity state. "
-                    "Example: '{{ states(\"sensor.temperature\") }}'"
+                    "Fields to update as key-value pairs. Only provided fields "
+                    "are changed; existing options are preserved."
                 ),
-            },
-            "unit_of_measurement": {
-                "type": "string",
-                "description": "New unit of measurement (sensor only, optional)",
-            },
-            "device_class": {
-                "type": "string",
-                "description": "New device class (optional, omit to clear)",
-            },
-            "state_class": {
-                "type": "string",
-                "description": (
-                    "New state class (sensor only, optional). Valid values: "
-                    "measurement, measurement_angle, total, total_increasing"
-                ),
-            },
-            "availability": {
-                "type": "string",
-                "description": "New Jinja2 availability template (optional)",
             },
         },
-        "required": ["entry_id"],
+        "required": ["entry_id", "updates"],
     },
     permission="helpers_update",
 )
-async def update_template_helper(
+async def update_config_entry_helper(
     hass: HomeAssistant, arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Update a template-based helper via Options Flow."""
+    """Update a config-entry-flow helper via Options Flow."""
     entry_id = arguments["entry_id"]
+    updates = arguments.get("updates", {})
 
-    # Verify the entry exists and is a template helper
     entry = hass.config_entries.async_get_entry(entry_id)
     if entry is None:
         raise ValueError(f"Config entry '{entry_id}' not found")
 
-    if entry.domain != "template":
+    if entry.domain not in CONFIG_ENTRY_HELPER_DOMAINS:
         raise ValueError(
-            f"Config entry '{entry_id}' is not a template helper "
+            f"Config entry '{entry_id}' is not a config-entry helper "
             f"(domain: {entry.domain})"
         )
 
     if not entry.supports_options:
         raise ValueError(
-            f"Template helper '{entry.title}' does not support options updates"
+            f"Helper '{entry.title}' ({entry.domain}) does not support "
+            f"options updates"
         )
 
-    # Start the options flow
-    try:
-        result = await hass.config_entries.options.async_init(entry_id)
-    except Exception as err:
-        raise ValueError(
-            f"Failed to start options flow for '{entry.title}': {err}"
-        ) from err
+    if not updates:
+        raise ValueError("No update fields provided")
 
-    flow_id = result["flow_id"]
+    # Remove empty string values that could cause enum validation errors
+    clean_updates = {
+        k: v for k, v in updates.items() if v is not None and v != ""
+    }
 
-    # Build update data from current options merged with provided updates
-    current_options = dict(entry.options)
-    update_data: dict[str, Any] = {}
-
-    # Carry forward existing values, override with provided ones
-    for field in ("name", "state", "unit_of_measurement", "device_class",
-                  "state_class", "availability"):
-        if field in arguments:
-            # Only include non-empty values for enum fields
-            if arguments[field]:
-                update_data[field] = arguments[field]
-        elif field in current_options:
-            update_data[field] = current_options[field]
-
-    try:
-        result = await hass.config_entries.options.async_configure(
-            flow_id, update_data
-        )
-    except Exception as err:
-        raise ValueError(
-            f"Failed to update template helper: {err}"
-        ) from err
+    await _follow_options_flow(hass, entry_id, clean_updates)
 
     return {
         "entry_id": entry_id,
         "title": entry.title,
-        "domain": "template",
-        "template_type": entry.options.get("template_type", ""),
-        "options": update_data,
-        "message": f"Template helper '{entry.title}' updated",
+        "domain": entry.domain,
+        "updates": clean_updates,
+        "message": f"{entry.domain} helper '{entry.title}' updated",
     }
 
 
+# =============================================================================
+# Delete Config Entry Helper
+# =============================================================================
+
 @mcp_tool(
-    name="ha_delete_template_helper",
+    name="ha_delete_config_entry_helper",
     description=(
-        "Delete a template-based helper by its config entry ID. Use "
-        "ha_list_template_helpers to find entry IDs. This action cannot be undone."
+        "Delete a config-entry-flow helper by its config entry ID. This action "
+        "cannot be undone. Use ha_list_config_entry_helpers to find entry IDs."
     ),
     schema={
         "type": "object",
@@ -1335,8 +1456,8 @@ async def update_template_helper(
             "entry_id": {
                 "type": "string",
                 "description": (
-                    "The config entry ID of the template helper to delete. "
-                    "Get this from ha_list_template_helpers."
+                    "The config entry ID to delete. Get this from "
+                    "ha_list_config_entry_helpers."
                 ),
             },
         },
@@ -1344,34 +1465,34 @@ async def update_template_helper(
     },
     permission="helpers_delete",
 )
-async def delete_template_helper(
+async def delete_config_entry_helper(
     hass: HomeAssistant, arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Delete a template-based helper by config entry ID."""
+    """Delete a config-entry-flow helper."""
     entry_id = arguments["entry_id"]
 
-    # Verify the entry exists and is a template helper
     entry = hass.config_entries.async_get_entry(entry_id)
     if entry is None:
         raise ValueError(f"Config entry '{entry_id}' not found")
 
-    if entry.domain != "template":
+    if entry.domain not in CONFIG_ENTRY_HELPER_DOMAINS:
         raise ValueError(
-            f"Config entry '{entry_id}' is not a template helper "
+            f"Config entry '{entry_id}' is not a config-entry helper "
             f"(domain: {entry.domain})"
         )
 
     title = entry.title
+    domain = entry.domain
 
     try:
         result = await hass.config_entries.async_remove(entry_id)
     except Exception as err:
-        raise ValueError(f"Failed to delete template helper: {err}") from err
+        raise ValueError(f"Failed to delete helper: {err}") from err
 
     return {
         "deleted": entry_id,
         "title": title,
-        "domain": "template",
+        "domain": domain,
         "require_restart": result.get("require_restart", False),
-        "message": f"Template helper '{title}' deleted",
+        "message": f"{domain} helper '{title}' deleted",
     }

--- a/custom_components/config_mcp_test/tools/helpers.py
+++ b/custom_components/config_mcp_test/tools/helpers.py
@@ -1,8 +1,9 @@
 """MCP Tools for Home Assistant Helpers.
 
 Provides tools for managing Home Assistant helpers (input_boolean, input_number,
-input_text, input_select, input_datetime, counter, timer) via the Home Assistant
-Store API for direct storage file access.
+input_text, input_select, input_datetime, counter, timer) via Home Assistant's
+internal StorageCollection API, which keeps in-memory state and .storage files
+in sync (fixing BUG 3 — Store API cache bypass).
 
 Each tool registers itself using the @mcp_tool decorator.
 """
@@ -10,7 +11,6 @@ Each tool registers itself using the @mcp_tool decorator.
 from __future__ import annotations
 
 import logging
-import uuid
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -22,30 +22,39 @@ from ..const import HELPER_DOMAINS
 
 _LOGGER = logging.getLogger(__name__)
 
-# Storage version must match Home Assistant's internal version for these domains
+# Storage version for reading helpers via Store API (list/get operations)
 STORAGE_VERSION = 1
+
+# Key used by HA's collection.store_entity_registry_items() to store
+# StorageCollection instances in hass.data
+COLLECTION_INSTANCES_KEY = "collection_instances"
 
 
 # Domain-specific required fields for creation
 HELPER_CREATE_FIELDS: dict[str, list[str]] = {
     "input_boolean": [],  # Only name required
+    "input_button": [],  # Only name required
     "input_number": ["min", "max"],  # min and max are required
     "input_text": [],  # Only name required
     "input_select": ["options"],  # options list is required
     "input_datetime": [],  # Only name required
     "counter": [],  # Only name required
     "timer": [],  # Only name required
+    "schedule": [],  # Only name required; schedule blocks added separately
 }
 
 # Domain-specific optional fields
 HELPER_OPTIONAL_FIELDS: dict[str, list[str]] = {
     "input_boolean": ["icon"],
+    "input_button": ["icon"],
     "input_number": ["icon", "mode", "step", "unit_of_measurement"],
     "input_text": ["icon", "min", "max", "pattern", "mode"],
     "input_select": ["icon"],
     "input_datetime": ["icon", "has_date", "has_time"],
     "counter": ["icon", "initial", "minimum", "maximum", "step", "restore"],
     "timer": ["icon", "duration", "restore"],
+    "schedule": ["icon", "monday", "tuesday", "wednesday", "thursday",
+                 "friday", "saturday", "sunday"],
 }
 
 
@@ -120,23 +129,38 @@ async def _get_helper_by_id(
     return None, None
 
 
-def _generate_helper_id(name: str) -> str:
-    """Generate a helper ID from the name.
+def _get_storage_collection(hass: HomeAssistant, domain: str) -> Any:
+    """Get Home Assistant's internal StorageCollection for a helper domain.
+
+    This accesses the same collection that HA's WebSocket commands
+    ({domain}/create, {domain}/update, {domain}/delete) use, ensuring
+    in-memory state and disk storage stay in sync.
 
     Args:
-        name: The helper name
+        hass: Home Assistant instance
+        domain: The helper domain (e.g., 'input_boolean')
 
     Returns:
-        A valid helper ID
+        The StorageCollection instance for the domain
+
+    Raises:
+        ValueError: If the collection is not found
     """
-    # Convert name to lowercase and replace spaces with underscores
-    helper_id = name.lower().replace(" ", "_")
-    # Remove any characters that aren't alphanumeric or underscores
-    helper_id = "".join(c for c in helper_id if c.isalnum() or c == "_")
-    # Ensure it doesn't start with a number
-    if helper_id and helper_id[0].isdigit():
-        helper_id = f"_{helper_id}"
-    return helper_id or f"helper_{uuid.uuid4().hex[:8]}"
+    instances = hass.data.get(COLLECTION_INSTANCES_KEY)
+    if instances is None:
+        raise ValueError(
+            f"No storage collections found in hass.data. "
+            f"Ensure the {domain} integration is loaded."
+        )
+
+    collection = instances.get(domain)
+    if collection is None:
+        raise ValueError(
+            f"No storage collection found for domain '{domain}'. "
+            f"Ensure the {domain} integration is loaded."
+        )
+
+    return collection
 
 
 async def _create_helper(
@@ -144,7 +168,10 @@ async def _create_helper(
     domain: str,
     config: dict[str, Any],
 ) -> dict[str, Any]:
-    """Create a new helper using the Store API.
+    """Create a new helper using HA's internal StorageCollection.
+
+    Uses the same collection that WebSocket commands ({domain}/create) use,
+    keeping in-memory state and .storage files in sync.
 
     Args:
         hass: Home Assistant instance
@@ -160,43 +187,27 @@ async def _create_helper(
     if domain not in HELPER_DOMAINS:
         raise ValueError(f"Invalid helper domain: {domain}")
 
-    # Use Store API to read/write .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
-    data = await store.async_load() or {"items": []}
+    collection = _get_storage_collection(hass, domain)
 
-    # Generate ID from name if not provided
-    helper_id = config.get("id") or _generate_helper_id(config["name"])
+    # Remove 'id' if present — the collection generates IDs automatically
+    create_data = {k: v for k, v in config.items() if k != "id"}
 
-    # Check for duplicate ID
-    existing_ids = {item.get("id") for item in data.get("items", [])}
-    if helper_id in existing_ids:
-        raise ValueError(f"Helper with ID '{helper_id}' already exists")
-
-    # Build the helper configuration
-    new_helper = {
-        "id": helper_id,
-        **config,
-    }
-
-    # Add to items list
-    if "items" not in data:
-        data["items"] = []
-    data["items"].append(new_helper)
-
-    # Save to storage
-    await store.async_save(data)
-
-    # Reload the domain to pick up the new helper
     try:
-        await hass.services.async_call(domain, "reload", blocking=True)
-    except Exception as err:
-        _LOGGER.warning("Failed to reload %s after creation: %s", domain, err)
+        item = await collection.async_create_item(create_data)
+    except ValueError as err:
+        raise ValueError(f"Failed to create helper: {err}") from err
+
+    # The collection returns the created item (dict or object with as_dict())
+    if hasattr(item, "as_dict"):
+        item_data = item.as_dict()
+    elif isinstance(item, dict):
+        item_data = item
+    else:
+        item_data = {"id": str(item)}
 
     return {
-        "id": helper_id,
-        "name": config.get("name"),
         "domain": domain,
-        **{k: v for k, v in new_helper.items() if k not in ("id", "name")},
+        **item_data,
     }
 
 
@@ -206,7 +217,10 @@ async def _update_helper(
     helper_id: str,
     updates: dict[str, Any],
 ) -> dict[str, Any]:
-    """Update an existing helper using the Store API.
+    """Update an existing helper using HA's internal StorageCollection.
+
+    Uses the same collection that WebSocket commands ({domain}/update) use,
+    keeping in-memory state and .storage files in sync.
 
     Args:
         hass: Home Assistant instance
@@ -220,42 +234,28 @@ async def _update_helper(
     Raises:
         ValueError: If update fails
     """
-    # Use Store API to read/write .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
-    data = await store.async_load()
+    collection = _get_storage_collection(hass, domain)
 
-    if data is None:
-        raise ValueError(f"Helper domain {domain} has no stored data")
+    # Remove 'id' and 'domain' from updates — these can't be changed
+    update_data = {k: v for k, v in updates.items() if k not in ("id", "domain")}
 
-    items = data.get("items", [])
-
-    # Find and update the helper
-    updated_item = None
-    for i, item in enumerate(items):
-        if isinstance(item, dict) and item.get("id") == helper_id:
-            # Merge updates with existing item (don't change id)
-            items[i] = {**item, **updates, "id": helper_id}
-            updated_item = items[i]
-            break
-
-    if updated_item is None:
-        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
-
-    # Save to storage
-    data["items"] = items
-    await store.async_save(data)
-
-    # Reload the domain to pick up the changes
     try:
-        await hass.services.async_call(domain, "reload", blocking=True)
-    except Exception as err:
-        _LOGGER.warning("Failed to reload %s after update: %s", domain, err)
+        item = await collection.async_update_item(helper_id, update_data)
+    except KeyError:
+        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
+    except ValueError as err:
+        raise ValueError(f"Failed to update helper: {err}") from err
+
+    if hasattr(item, "as_dict"):
+        item_data = item.as_dict()
+    elif isinstance(item, dict):
+        item_data = item
+    else:
+        item_data = {"id": helper_id}
 
     return {
-        "id": updated_item.get("id"),
-        "name": updated_item.get("name"),
         "domain": domain,
-        **{k: v for k, v in updated_item.items() if k not in ("id", "name")},
+        **item_data,
     }
 
 
@@ -264,7 +264,10 @@ async def _delete_helper(
     domain: str,
     helper_id: str,
 ) -> None:
-    """Delete a helper using the Store API.
+    """Delete a helper using HA's internal StorageCollection.
+
+    Uses the same collection that WebSocket commands ({domain}/delete) use,
+    keeping in-memory state and .storage files in sync.
 
     Args:
         hass: Home Assistant instance
@@ -274,31 +277,12 @@ async def _delete_helper(
     Raises:
         ValueError: If deletion fails
     """
-    # Use Store API to read/write .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
-    data = await store.async_load()
+    collection = _get_storage_collection(hass, domain)
 
-    if data is None:
-        raise ValueError(f"Helper domain {domain} has no stored data")
-
-    items = data.get("items", [])
-
-    # Find and remove the helper
-    original_count = len(items)
-    items = [item for item in items if not (isinstance(item, dict) and item.get("id") == helper_id)]
-
-    if len(items) == original_count:
-        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
-
-    # Save to storage
-    data["items"] = items
-    await store.async_save(data)
-
-    # Reload the domain to pick up the changes
     try:
-        await hass.services.async_call(domain, "reload", blocking=True)
-    except Exception as err:
-        _LOGGER.warning("Failed to reload %s after deletion: %s", domain, err)
+        await collection.async_delete_item(helper_id)
+    except KeyError:
+        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
 
 
 def _format_helper(
@@ -353,6 +337,11 @@ def _format_helper(
     elif domain == "timer":
         data["duration"] = helper_config.get("duration")
         data["restore"] = helper_config.get("restore")
+    elif domain == "schedule":
+        for day in ("monday", "tuesday", "wednesday", "thursday",
+                    "friday", "saturday", "sunday"):
+            if day in helper_config:
+                data[day] = helper_config[day]
 
     # Add entity registry info if available
     if entity_entry:
@@ -520,12 +509,14 @@ async def get_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         "Create a new helper entity. Requires specifying the helper domain and "
         "name. Additional fields depend on the domain:\n"
         "- input_boolean: icon\n"
+        "- input_button: icon\n"
         "- input_number: min (required), max (required), step, mode, unit_of_measurement, icon\n"
         "- input_text: min, max, pattern, mode, icon\n"
         "- input_select: options (required), icon\n"
         "- input_datetime: has_date, has_time, icon\n"
         "- counter: initial, minimum, maximum, step, restore, icon\n"
-        "- timer: duration, restore, icon"
+        "- timer: duration, restore, icon\n"
+        "- schedule: icon, monday..sunday (each an array of {from, to, data} blocks)"
     ),
     schema={
         "type": "object",
@@ -605,6 +596,42 @@ async def get_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
             "duration": {
                 "type": "string",
                 "description": "Default duration for timer (e.g., '00:01:00' for 1 minute)",
+            },
+            # schedule fields (each day is an array of time blocks)
+            "monday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Monday schedule blocks: [{from: '08:00:00', to: '17:00:00'}]",
+            },
+            "tuesday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Tuesday schedule blocks",
+            },
+            "wednesday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Wednesday schedule blocks",
+            },
+            "thursday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Thursday schedule blocks",
+            },
+            "friday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Friday schedule blocks",
+            },
+            "saturday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Saturday schedule blocks",
+            },
+            "sunday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Sunday schedule blocks",
             },
         },
         "required": ["domain", "name"],
@@ -749,6 +776,42 @@ async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
                 "type": "string",
                 "description": "New default duration (timer)",
             },
+            # schedule fields
+            "monday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Monday schedule blocks",
+            },
+            "tuesday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Tuesday schedule blocks",
+            },
+            "wednesday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Wednesday schedule blocks",
+            },
+            "thursday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Thursday schedule blocks",
+            },
+            "friday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Friday schedule blocks",
+            },
+            "saturday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Saturday schedule blocks",
+            },
+            "sunday": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "New Sunday schedule blocks",
+            },
         },
         "required": ["entity_id"],
     },
@@ -853,4 +916,462 @@ async def delete_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         "deleted": entity_id,
         "domain": domain,
         "message": f"{domain} helper deleted",
+    }
+
+
+# =============================================================================
+# Template Helper Tools (Config Entry Flow API)
+# =============================================================================
+
+# Template sub-types available for creation
+TEMPLATE_TYPES = [
+    "alarm_control_panel", "binary_sensor", "button", "cover",
+    "event", "fan", "image", "light", "lock", "number",
+    "select", "sensor", "switch", "update", "vacuum", "weather",
+]
+
+
+@mcp_tool(
+    name="ha_list_template_helpers",
+    description=(
+        "List all template-based helpers (template sensors, binary sensors, "
+        "switches, etc.) that are created via Config Entry flows. These are "
+        "distinct from input_* helpers. Returns entry_id, title, template_type, "
+        "and configuration for each template helper."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "template_type": {
+                "type": "string",
+                "description": (
+                    "Filter by template sub-type (e.g., 'sensor', 'binary_sensor', "
+                    "'switch'). If omitted, returns all template helpers."
+                ),
+                "enum": TEMPLATE_TYPES,
+            },
+        },
+    },
+    permission="helpers_read",
+)
+async def list_template_helpers(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """List all template-based helpers."""
+    type_filter = arguments.get("template_type")
+    entries = hass.config_entries.async_entries("template")
+
+    results = []
+    for entry in entries:
+        template_type = entry.options.get("template_type", "")
+        if type_filter and template_type != type_filter:
+            continue
+
+        results.append({
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "domain": "template",
+            "template_type": template_type,
+            "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
+            "options": dict(entry.options),
+        })
+
+    results.sort(key=lambda x: (x.get("template_type", ""), x.get("title", "").lower()))
+    return results
+
+
+@mcp_tool(
+    name="ha_get_template_helper",
+    description=(
+        "Get full details for a specific template-based helper by its config "
+        "entry ID. Returns the entry configuration, options, template type, "
+        "and current state."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "entry_id": {
+                "type": "string",
+                "description": (
+                    "The config entry ID of the template helper. "
+                    "Get this from ha_list_template_helpers."
+                ),
+            },
+        },
+        "required": ["entry_id"],
+    },
+    permission="helpers_read",
+)
+async def get_template_helper(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Get a specific template-based helper by config entry ID."""
+    entry_id = arguments["entry_id"]
+
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None:
+        raise ValueError(f"Config entry '{entry_id}' not found")
+
+    if entry.domain != "template":
+        raise ValueError(
+            f"Config entry '{entry_id}' is not a template helper "
+            f"(domain: {entry.domain})"
+        )
+
+    template_type = entry.options.get("template_type", "")
+
+    result: dict[str, Any] = {
+        "entry_id": entry.entry_id,
+        "title": entry.title,
+        "domain": "template",
+        "template_type": template_type,
+        "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
+        "supports_options": entry.supports_options,
+        "supports_unload": entry.supports_unload,
+        "options": dict(entry.options),
+    }
+
+    # Find the entity associated with this config entry
+    entity_registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(entity_registry, entry_id)
+    if entities:
+        entity_entries = []
+        for entity_entry in entities:
+            entity_data: dict[str, Any] = {
+                "entity_id": entity_entry.entity_id,
+                "name": entity_entry.name or entity_entry.original_name,
+                "area_id": entity_entry.area_id,
+                "disabled": entity_entry.disabled_by is not None,
+                "labels": list(entity_entry.labels) if entity_entry.labels else [],
+            }
+            # Add current state
+            state = hass.states.get(entity_entry.entity_id)
+            if state:
+                entity_data["current_state"] = {
+                    "state": state.state,
+                    "attributes": dict(state.attributes),
+                    "last_changed": state.last_changed.isoformat() if state.last_changed else None,
+                }
+            entity_entries.append(entity_data)
+        result["entities"] = entity_entries
+
+    return result
+
+
+@mcp_tool(
+    name="ha_create_template_helper",
+    description=(
+        "Create a template-based helper (template sensor, binary sensor, switch, "
+        "etc.) using Home Assistant's Config Entry Flow API. This is a 3-step "
+        "process handled automatically.\n\n"
+        "Common template_type values: sensor, binary_sensor, switch, number, "
+        "select, button, light, cover, fan, lock, vacuum, weather.\n\n"
+        "The 'state' field is a Jinja2 template string, e.g.:\n"
+        "  '{{ states(\"sensor.temperature\") }}'\n"
+        "  '{{ is_state(\"binary_sensor.door\", \"on\") }}'\n\n"
+        "IMPORTANT: Optional enum fields (device_class, state_class) must be "
+        "omitted entirely if not needed — empty strings cause validation errors."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "template_type": {
+                "type": "string",
+                "description": (
+                    "The type of template helper to create. Common values: "
+                    "sensor, binary_sensor, switch, number, select, button, "
+                    "light, cover, fan, lock, vacuum, weather"
+                ),
+                "enum": TEMPLATE_TYPES,
+            },
+            "name": {
+                "type": "string",
+                "description": "Human-readable name for the template helper (required)",
+            },
+            "state": {
+                "type": "string",
+                "description": (
+                    "Jinja2 template for the entity state (required). "
+                    "Example: '{{ states(\"sensor.time\") }}'"
+                ),
+            },
+            "unit_of_measurement": {
+                "type": "string",
+                "description": "Unit of measurement (sensor only, optional)",
+            },
+            "device_class": {
+                "type": "string",
+                "description": (
+                    "Device class for the entity (optional). Must be a valid "
+                    "value for the template_type — omit if not needed."
+                ),
+            },
+            "state_class": {
+                "type": "string",
+                "description": (
+                    "State class (sensor only, optional). Valid values: "
+                    "measurement, measurement_angle, total, total_increasing. "
+                    "Omit if not needed."
+                ),
+            },
+            "availability": {
+                "type": "string",
+                "description": (
+                    "Jinja2 template for availability (optional). "
+                    "Should evaluate to true/false."
+                ),
+            },
+            "device_id": {
+                "type": "string",
+                "description": "Device to associate the helper with (optional)",
+            },
+        },
+        "required": ["template_type", "name", "state"],
+    },
+    permission="helpers_create",
+)
+async def create_template_helper(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Create a template-based helper via Config Entry Flow."""
+    template_type = arguments["template_type"]
+    name = arguments["name"]
+    state = arguments["state"]
+
+    # Step 1: Initiate the config entry flow
+    try:
+        result = await hass.config_entries.flow.async_init(
+            "template", context={"source": "user"}
+        )
+    except Exception as err:
+        raise ValueError(
+            f"Failed to initiate template config flow: {err}. "
+            f"Ensure the 'template' integration is loaded."
+        ) from err
+
+    flow_id = result["flow_id"]
+
+    # Step 2: Select the template sub-type
+    try:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {"next_step_id": template_type}
+        )
+    except Exception as err:
+        raise ValueError(
+            f"Failed to select template type '{template_type}': {err}"
+        ) from err
+
+    # Step 3: Submit the configuration
+    config_data: dict[str, Any] = {
+        "name": name,
+        "state": state,
+    }
+
+    # Add optional fields only if provided (empty strings cause validation errors)
+    for field in ("unit_of_measurement", "device_class", "state_class",
+                  "availability", "device_id"):
+        if field in arguments and arguments[field]:
+            config_data[field] = arguments[field]
+
+    try:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, config_data
+        )
+    except Exception as err:
+        raise ValueError(
+            f"Failed to create template helper: {err}"
+        ) from err
+
+    if result.get("type") != "create_entry":
+        raise ValueError(
+            f"Unexpected flow result type: {result.get('type')}. "
+            f"Expected 'create_entry'. Result: {result}"
+        )
+
+    entry_result = result.get("result", {})
+    entry_id = (
+        entry_result.entry_id
+        if hasattr(entry_result, "entry_id")
+        else entry_result.get("entry_id")
+    )
+
+    return {
+        "entry_id": entry_id,
+        "title": result.get("title", name),
+        "domain": "template",
+        "template_type": template_type,
+        "options": result.get("options", config_data),
+        "message": f"Template {template_type} helper '{name}' created",
+    }
+
+
+@mcp_tool(
+    name="ha_update_template_helper",
+    description=(
+        "Update a template-based helper's configuration via the Options Flow API. "
+        "Use ha_list_template_helpers to find entry IDs and current options.\n\n"
+        "IMPORTANT: Optional enum fields (device_class, state_class) must be "
+        "omitted entirely if not needed — empty strings cause validation errors."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "entry_id": {
+                "type": "string",
+                "description": (
+                    "The config entry ID of the template helper to update. "
+                    "Get this from ha_list_template_helpers."
+                ),
+            },
+            "name": {
+                "type": "string",
+                "description": "New name for the template helper",
+            },
+            "state": {
+                "type": "string",
+                "description": (
+                    "New Jinja2 template for the entity state. "
+                    "Example: '{{ states(\"sensor.temperature\") }}'"
+                ),
+            },
+            "unit_of_measurement": {
+                "type": "string",
+                "description": "New unit of measurement (sensor only, optional)",
+            },
+            "device_class": {
+                "type": "string",
+                "description": "New device class (optional, omit to clear)",
+            },
+            "state_class": {
+                "type": "string",
+                "description": (
+                    "New state class (sensor only, optional). Valid values: "
+                    "measurement, measurement_angle, total, total_increasing"
+                ),
+            },
+            "availability": {
+                "type": "string",
+                "description": "New Jinja2 availability template (optional)",
+            },
+        },
+        "required": ["entry_id"],
+    },
+    permission="helpers_update",
+)
+async def update_template_helper(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Update a template-based helper via Options Flow."""
+    entry_id = arguments["entry_id"]
+
+    # Verify the entry exists and is a template helper
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None:
+        raise ValueError(f"Config entry '{entry_id}' not found")
+
+    if entry.domain != "template":
+        raise ValueError(
+            f"Config entry '{entry_id}' is not a template helper "
+            f"(domain: {entry.domain})"
+        )
+
+    if not entry.supports_options:
+        raise ValueError(
+            f"Template helper '{entry.title}' does not support options updates"
+        )
+
+    # Start the options flow
+    try:
+        result = await hass.config_entries.options.async_init(entry_id)
+    except Exception as err:
+        raise ValueError(
+            f"Failed to start options flow for '{entry.title}': {err}"
+        ) from err
+
+    flow_id = result["flow_id"]
+
+    # Build update data from current options merged with provided updates
+    current_options = dict(entry.options)
+    update_data: dict[str, Any] = {}
+
+    # Carry forward existing values, override with provided ones
+    for field in ("name", "state", "unit_of_measurement", "device_class",
+                  "state_class", "availability"):
+        if field in arguments:
+            # Only include non-empty values for enum fields
+            if arguments[field]:
+                update_data[field] = arguments[field]
+        elif field in current_options:
+            update_data[field] = current_options[field]
+
+    try:
+        result = await hass.config_entries.options.async_configure(
+            flow_id, update_data
+        )
+    except Exception as err:
+        raise ValueError(
+            f"Failed to update template helper: {err}"
+        ) from err
+
+    return {
+        "entry_id": entry_id,
+        "title": entry.title,
+        "domain": "template",
+        "template_type": entry.options.get("template_type", ""),
+        "options": update_data,
+        "message": f"Template helper '{entry.title}' updated",
+    }
+
+
+@mcp_tool(
+    name="ha_delete_template_helper",
+    description=(
+        "Delete a template-based helper by its config entry ID. Use "
+        "ha_list_template_helpers to find entry IDs. This action cannot be undone."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "entry_id": {
+                "type": "string",
+                "description": (
+                    "The config entry ID of the template helper to delete. "
+                    "Get this from ha_list_template_helpers."
+                ),
+            },
+        },
+        "required": ["entry_id"],
+    },
+    permission="helpers_delete",
+)
+async def delete_template_helper(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Delete a template-based helper by config entry ID."""
+    entry_id = arguments["entry_id"]
+
+    # Verify the entry exists and is a template helper
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None:
+        raise ValueError(f"Config entry '{entry_id}' not found")
+
+    if entry.domain != "template":
+        raise ValueError(
+            f"Config entry '{entry_id}' is not a template helper "
+            f"(domain: {entry.domain})"
+        )
+
+    title = entry.title
+
+    try:
+        result = await hass.config_entries.async_remove(entry_id)
+    except Exception as err:
+        raise ValueError(f"Failed to delete template helper: {err}") from err
+
+    return {
+        "deleted": entry_id,
+        "title": title,
+        "domain": "template",
+        "require_restart": result.get("require_restart", False),
+        "message": f"Template helper '{title}' deleted",
     }

--- a/custom_components/config_mcp_test/tools/helpers.py
+++ b/custom_components/config_mcp_test/tools/helpers.py
@@ -134,9 +134,9 @@ async def _get_helper_by_id(
 def _get_storage_collection(hass: HomeAssistant, domain: str) -> Any:
     """Get Home Assistant's internal StorageCollection for a helper domain.
 
-    This accesses the same collection that HA's WebSocket commands
-    ({domain}/create, {domain}/update, {domain}/delete) use, ensuring
-    in-memory state and disk storage stay in sync.
+    Retrieves the StorageCollection by looking up the registered WebSocket
+    handler for '{domain}/create', which is a bound method on the
+    StorageCollectionWebsocket instance that holds a reference to the collection.
 
     Args:
         hass: Home Assistant instance
@@ -148,21 +148,42 @@ def _get_storage_collection(hass: HomeAssistant, domain: str) -> Any:
     Raises:
         ValueError: If the collection is not found
     """
-    instances = hass.data.get(COLLECTION_INSTANCES_KEY)
-    if instances is None:
+    # WS commands are stored in hass.data["websocket_api"][command_type]
+    ws_handlers = hass.data.get("websocket_api")
+    if ws_handlers is None:
         raise ValueError(
-            f"No storage collections found in hass.data. "
+            f"WebSocket API not initialized. Cannot access {domain} collection."
+        )
+
+    # The handler for '{domain}/create' is a bound method on the
+    # StorageCollectionWebsocket instance which exposes .storage_collection
+    handler_info = ws_handlers.get(f"{domain}/create")
+    if handler_info is None:
+        raise ValueError(
+            f"No WebSocket handler for '{domain}/create'. "
             f"Ensure the {domain} integration is loaded."
         )
 
-    collection = instances.get(domain)
-    if collection is None:
+    # handler_info may be the handler directly or a tuple (handler, schema)
+    handler = handler_info[0] if isinstance(handler_info, tuple) else handler_info
+
+    # Unwrap require_admin / async_response decorators to get the bound method
+    while hasattr(handler, "__wrapped__") or hasattr(handler, "func"):
+        handler = getattr(handler, "__wrapped__", None) or handler.func
+
+    ws_instance = getattr(handler, "__self__", None)
+    if ws_instance is None:
         raise ValueError(
-            f"No storage collection found for domain '{domain}'. "
-            f"Ensure the {domain} integration is loaded."
+            f"Could not extract StorageCollectionWebsocket instance for {domain}."
         )
 
-    return collection
+    storage_collection = getattr(ws_instance, "storage_collection", None)
+    if storage_collection is None:
+        raise ValueError(
+            f"StorageCollectionWebsocket for {domain} has no storage_collection."
+        )
+
+    return storage_collection
 
 
 async def _create_helper(

--- a/custom_components/config_mcp_test/tools/helpers.py
+++ b/custom_components/config_mcp_test/tools/helpers.py
@@ -61,7 +61,11 @@ HELPER_OPTIONAL_FIELDS: dict[str, list[str]] = {
 
 
 async def _get_helpers_for_domain(hass: HomeAssistant, domain: str) -> list[dict[str, Any]]:
-    """Get all helpers for a specific domain using the Store API.
+    """Get all helpers for a specific domain.
+
+    Uses the StorageCollection's in-memory data when available (reflects
+    unsaved creates/updates/deletes immediately). Falls back to the Store
+    file if the collection isn't accessible.
 
     Args:
         hass: Home Assistant instance
@@ -72,7 +76,23 @@ async def _get_helpers_for_domain(hass: HomeAssistant, domain: str) -> list[dict
     """
     helpers = []
 
-    # Use Store API to read from .storage/{domain}
+    # Prefer the StorageCollection's in-memory data so changes are visible
+    # immediately without waiting for the 10-second save delay.
+    try:
+        collection = _get_storage_collection(hass, domain)
+        for item in collection.values():
+            if isinstance(item, dict):
+                helpers.append({
+                    "id": item.get("id"),
+                    "name": item.get("name"),
+                    "domain": domain,
+                    **{k: v for k, v in item.items() if k not in ("id", "name")},
+                })
+        return helpers
+    except ValueError:
+        pass  # Fall through to Store-based read
+
+    # Fallback: read from .storage/{domain} on disk
     # HA helper integrations use STORAGE_KEY = DOMAIN (no 'core.' prefix)
     store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, domain)
     data = await store.async_load()

--- a/custom_components/config_mcp_test/tools/helpers.py
+++ b/custom_components/config_mcp_test/tools/helpers.py
@@ -79,8 +79,8 @@ async def _get_helpers_for_domain(hass: HomeAssistant, domain: str) -> list[dict
     # Prefer the StorageCollection's in-memory data so changes are visible
     # immediately without waiting for the 10-second save delay.
     try:
-        collection = _get_storage_collection(hass, domain)
-        for item in collection.values():
+        storage_collection = _get_storage_collection(hass, domain)
+        for item in storage_collection.data.values():
             if isinstance(item, dict):
                 helpers.append({
                     "id": item.get("id"),
@@ -89,7 +89,7 @@ async def _get_helpers_for_domain(hass: HomeAssistant, domain: str) -> list[dict
                     **{k: v for k, v in item.items() if k not in ("id", "name")},
                 })
         return helpers
-    except ValueError:
+    except (ValueError, AttributeError):
         pass  # Fall through to Store-based read
 
     # Fallback: read from .storage/{domain} on disk

--- a/custom_components/config_mcp_test/translations/en.json
+++ b/custom_components/config_mcp_test/translations/en.json
@@ -28,6 +28,7 @@
           "automations": "Automations",
           "scripts": "Scripts",
           "scenes": "Scenes",
+          "helpers": "Helpers",
           "categories": "Categories & Labels"
         }
       },
@@ -127,6 +128,22 @@
           "scenes_create": "Create new scenes",
           "scenes_update": "Update scene config and entities",
           "scenes_delete": "Delete scenes"
+        }
+      },
+      "helpers": {
+        "title": "Helpers",
+        "description": "Configure helper management for input_* helpers (input_boolean, input_number, input_text, input_select, input_datetime, counter, timer) and template-based helpers (template sensors, binary sensors, switches, etc.).\n\n**MCP Tools:** `ha_list_helpers`, `ha_create_helper`, `ha_update_helper`, `ha_delete_helper`, `ha_list_template_helpers`, `ha_create_template_helper`, `ha_update_template_helper`, `ha_delete_template_helper`\n**REST Endpoint:** `/api/config_mcp/helpers`",
+        "data": {
+          "helpers_read": "Read",
+          "helpers_create": "Create",
+          "helpers_update": "Update",
+          "helpers_delete": "Delete"
+        },
+        "data_description": {
+          "helpers_read": "List and get input_* helpers and template-based helpers",
+          "helpers_create": "Create new input_* helpers and template helpers (sensors, binary sensors, switches, etc.)",
+          "helpers_update": "Update helper configuration and settings",
+          "helpers_delete": "Delete helpers permanently"
         }
       },
       "categories": {

--- a/custom_components/config_mcp_test/views/__init__.py
+++ b/custom_components/config_mcp_test/views/__init__.py
@@ -61,10 +61,10 @@ from .categories import (
     LabelListView,
 )
 from .helpers import (
+    ConfigEntryHelperDetailView,
+    ConfigEntryHelperListView,
     HelperDetailView,
     HelperListView,
-    TemplateHelperDetailView,
-    TemplateHelperListView,
 )
 
 __all__ = [
@@ -119,7 +119,7 @@ __all__ = [
     # Helper views
     "HelperListView",
     "HelperDetailView",
-    # Template helper views
-    "TemplateHelperListView",
-    "TemplateHelperDetailView",
+    # Config entry helper views
+    "ConfigEntryHelperListView",
+    "ConfigEntryHelperDetailView",
 ]

--- a/custom_components/config_mcp_test/views/__init__.py
+++ b/custom_components/config_mcp_test/views/__init__.py
@@ -63,6 +63,8 @@ from .categories import (
 from .helpers import (
     HelperDetailView,
     HelperListView,
+    TemplateHelperDetailView,
+    TemplateHelperListView,
 )
 
 __all__ = [
@@ -117,4 +119,7 @@ __all__ = [
     # Helper views
     "HelperListView",
     "HelperDetailView",
+    # Template helper views
+    "TemplateHelperListView",
+    "TemplateHelperDetailView",
 ]

--- a/custom_components/config_mcp_test/views/helpers.py
+++ b/custom_components/config_mcp_test/views/helpers.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ..const import (
     API_BASE_PATH_HELPERS,
-    API_BASE_PATH_TEMPLATE_HELPERS,
+    API_BASE_PATH_CONFIG_ENTRY_HELPERS,
     CONF_HELPERS_CREATE,
     CONF_HELPERS_DELETE,
     CONF_HELPERS_READ,
@@ -28,6 +28,13 @@ from ..const import (
     ERR_HELPER_NOT_FOUND,
     ERR_INVALID_CONFIG,
     HELPER_DOMAINS,
+    CONFIG_ENTRY_HELPER_DOMAINS,
+)
+
+from ..tools.helpers import (
+    _follow_config_flow,
+    _follow_options_flow,
+    _extract_form_data,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -651,29 +658,22 @@ class HelperDetailView(HomeAssistantView):
         return web.Response(status=HTTPStatus.NO_CONTENT)
 
 
-# Template sub-types available for creation
-TEMPLATE_TYPES = [
-    "alarm_control_panel", "binary_sensor", "button", "cover",
-    "event", "fan", "image", "light", "lock", "number",
-    "select", "sensor", "switch", "update", "vacuum", "weather",
-]
+class ConfigEntryHelperListView(HomeAssistantView):
+    """View to list and create config-entry-flow helpers."""
 
-
-class TemplateHelperListView(HomeAssistantView):
-    """View to list and create template-based helpers."""
-
-    url = API_BASE_PATH_TEMPLATE_HELPERS
-    name = "api:config_mcp:template_helpers"
+    url = API_BASE_PATH_CONFIG_ENTRY_HELPERS
+    name = "api:config_mcp:config_entry_helpers"
     requires_auth = True
 
     async def get(self, request: web.Request) -> web.Response:
-        """Handle GET request - list all template helpers.
+        """Handle GET request - list config entry helpers.
 
         Query params:
-            template_type: Optional filter (e.g., 'sensor', 'binary_sensor')
+            domain: Optional filter by integration domain
+            sub_type: Optional filter by sub-type
 
         Returns:
-            200: JSON array of template helper data
+            200: JSON array of helper data
             403: Permission denied
         """
         hass: HomeAssistant = request.app["hass"]
@@ -684,43 +684,66 @@ class TemplateHelperListView(HomeAssistantView):
                 HTTPStatus.FORBIDDEN,
             )
 
-        type_filter = request.query.get("template_type")
-        entries = hass.config_entries.async_entries("template")
+        domain_filter = request.query.get("domain")
+        sub_type_filter = request.query.get("sub_type")
+
+        domains = (
+            [domain_filter] if domain_filter
+            else CONFIG_ENTRY_HELPER_DOMAINS
+        )
 
         results = []
-        for entry in entries:
-            template_type = entry.options.get("template_type", "")
-            if type_filter and template_type != type_filter:
+        for domain in domains:
+            try:
+                entries = hass.config_entries.async_entries(domain)
+            except Exception:
                 continue
 
-            results.append({
-                "entry_id": entry.entry_id,
-                "title": entry.title,
-                "domain": "template",
-                "template_type": template_type,
-                "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
-                "options": dict(entry.options),
-            })
+            for entry in entries:
+                if sub_type_filter:
+                    entry_options = entry.options or {}
+                    entry_sub_type = (
+                        entry_options.get("template_type")
+                        or entry_options.get("group_type")
+                        or entry_options.get("type")
+                        or ""
+                    )
+                    if entry_sub_type != sub_type_filter:
+                        continue
 
-        results.sort(key=lambda x: (x.get("template_type", ""), x.get("title", "").lower()))
+                results.append({
+                    "entry_id": entry.entry_id,
+                    "title": entry.title,
+                    "domain": entry.domain,
+                    "state": (
+                        entry.state.value
+                        if hasattr(entry.state, "value")
+                        else str(entry.state)
+                    ),
+                    "options": dict(entry.options) if entry.options else {},
+                })
+
+        results.sort(
+            key=lambda x: (x["domain"], x.get("title", "").lower())
+        )
         return self.json(results)
 
     async def post(self, request: web.Request) -> web.Response:
-        """Handle POST request - create a template helper.
+        """Handle POST request - create a config entry helper.
 
         Request body:
             {
-                "template_type": "sensor",  (required)
-                "name": "My Sensor",  (required)
-                "state": "{{ states('sensor.x') }}",  (required)
-                "unit_of_measurement": "°C",  (optional)
-                "device_class": "temperature",  (optional, omit if not set)
-                "state_class": "measurement",  (optional, omit if not set)
-                "availability": "{{ true }}",  (optional)
+                "domain": "template",  (required)
+                "sub_type": "sensor",  (required for menu domains)
+                "config": {            (required)
+                    "name": "My Sensor",
+                    "state": "{{ states('sensor.x') }}",
+                    ...domain-specific fields...
+                }
             }
 
         Returns:
-            201: Template helper created
+            201: Helper created
             400: Invalid request
             401: Not authorized
             403: Permission denied
@@ -749,64 +772,39 @@ class TemplateHelperListView(HomeAssistantView):
                 ERR_INVALID_CONFIG,
             )
 
-        template_type = body.get("template_type")
-        name = body.get("name")
-        state = body.get("state")
+        domain = body.get("domain")
+        sub_type = body.get("sub_type")
+        config_data = body.get("config", {})
 
-        if not template_type:
+        if not domain:
             return self.json_message(
-                "Missing required field: template_type",
+                "Missing required field: domain",
                 HTTPStatus.BAD_REQUEST,
                 ERR_HELPER_INVALID_CONFIG,
             )
 
-        if not name:
+        if domain not in CONFIG_ENTRY_HELPER_DOMAINS:
             return self.json_message(
-                "Missing required field: name",
+                f"Invalid domain '{domain}'. Valid: "
+                f"{', '.join(CONFIG_ENTRY_HELPER_DOMAINS)}",
                 HTTPStatus.BAD_REQUEST,
-                ERR_HELPER_INVALID_CONFIG,
-            )
-
-        if not state:
-            return self.json_message(
-                "Missing required field: state",
-                HTTPStatus.BAD_REQUEST,
-                ERR_HELPER_INVALID_CONFIG,
+                ERR_HELPER_INVALID_DOMAIN,
             )
 
         try:
-            # Step 1: Initiate config entry flow
-            result = await hass.config_entries.flow.async_init(
-                "template", context={"source": "user"}
+            result = await _follow_config_flow(
+                hass, domain, config_data, sub_type
             )
-            flow_id = result["flow_id"]
-
-            # Step 2: Select template sub-type
-            result = await hass.config_entries.flow.async_configure(
-                flow_id, {"next_step_id": template_type}
-            )
-
-            # Step 3: Submit configuration
-            config_data: dict[str, Any] = {"name": name, "state": state}
-            for field in ("unit_of_measurement", "device_class", "state_class",
-                          "availability", "device_id"):
-                if field in body and body[field]:
-                    config_data[field] = body[field]
-
-            result = await hass.config_entries.flow.async_configure(
-                flow_id, config_data
-            )
-        except Exception as err:
-            _LOGGER.exception("Error creating template helper: %s", err)
+        except ValueError as err:
             return self.json_message(
-                f"Error creating template helper: {err}",
+                str(err),
                 HTTPStatus.BAD_REQUEST,
                 ERR_HELPER_INVALID_CONFIG,
             )
-
-        if result.get("type") != "create_entry":
+        except Exception as err:
+            _LOGGER.exception("Error creating config entry helper: %s", err)
             return self.json_message(
-                f"Unexpected flow result: {result.get('type')}",
+                f"Error creating helper: {err}",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 
@@ -815,35 +813,37 @@ class TemplateHelperListView(HomeAssistantView):
             entry_result.entry_id
             if hasattr(entry_result, "entry_id")
             else entry_result.get("entry_id")
+            if isinstance(entry_result, dict)
+            else str(entry_result)
         )
 
         return self.json(
             {
                 "entry_id": entry_id,
-                "title": result.get("title", name),
-                "domain": "template",
-                "template_type": template_type,
+                "title": result.get("title", config_data.get("name", "")),
+                "domain": domain,
+                "sub_type": sub_type,
                 "options": result.get("options", config_data),
-                "message": "Template helper created",
+                "message": "Config entry helper created",
             },
             HTTPStatus.CREATED,
         )
 
 
-class TemplateHelperDetailView(HomeAssistantView):
-    """View for single template helper operations."""
+class ConfigEntryHelperDetailView(HomeAssistantView):
+    """View for single config-entry-flow helper operations."""
 
-    url = API_BASE_PATH_TEMPLATE_HELPERS + "/{entry_id}"
-    name = "api:config_mcp:template_helper"
+    url = API_BASE_PATH_CONFIG_ENTRY_HELPERS + "/{entry_id}"
+    name = "api:config_mcp:config_entry_helper"
     requires_auth = True
 
     async def get(
         self, request: web.Request, entry_id: str
     ) -> web.Response:
-        """Handle GET request - get a single template helper.
+        """Handle GET request - get a single config entry helper.
 
         Returns:
-            200: Template helper data with entities
+            200: Helper data with entities
             403: Permission denied
             404: Not found
         """
@@ -856,9 +856,9 @@ class TemplateHelperDetailView(HomeAssistantView):
             )
 
         entry = hass.config_entries.async_get_entry(entry_id)
-        if entry is None or entry.domain != "template":
+        if entry is None or entry.domain not in CONFIG_ENTRY_HELPER_DOMAINS:
             return self.json_message(
-                f"Template helper '{entry_id}' not found",
+                f"Config entry helper '{entry_id}' not found",
                 HTTPStatus.NOT_FOUND,
                 ERR_HELPER_NOT_FOUND,
             )
@@ -866,22 +866,29 @@ class TemplateHelperDetailView(HomeAssistantView):
         result: dict[str, Any] = {
             "entry_id": entry.entry_id,
             "title": entry.title,
-            "domain": "template",
-            "template_type": entry.options.get("template_type", ""),
-            "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
+            "domain": entry.domain,
+            "state": (
+                entry.state.value
+                if hasattr(entry.state, "value")
+                else str(entry.state)
+            ),
             "supports_options": entry.supports_options,
-            "options": dict(entry.options),
+            "options": dict(entry.options) if entry.options else {},
         }
 
         # Include associated entities with current state
         entity_registry = er.async_get(hass)
-        entities = er.async_entries_for_config_entry(entity_registry, entry_id)
+        entities = er.async_entries_for_config_entry(
+            entity_registry, entry_id
+        )
         if entities:
             entity_entries = []
             for entity_entry in entities:
                 entity_data: dict[str, Any] = {
                     "entity_id": entity_entry.entity_id,
-                    "name": entity_entry.name or entity_entry.original_name,
+                    "name": (
+                        entity_entry.name or entity_entry.original_name
+                    ),
                     "area_id": entity_entry.area_id,
                     "disabled": entity_entry.disabled_by is not None,
                 }
@@ -899,10 +906,10 @@ class TemplateHelperDetailView(HomeAssistantView):
     async def patch(
         self, request: web.Request, entry_id: str
     ) -> web.Response:
-        """Handle PATCH request - update a template helper via options flow.
+        """Handle PATCH request - update a config entry helper via options flow.
 
         Returns:
-            200: Template helper updated
+            200: Helper updated
             400: Invalid request
             401: Not authorized
             403: Permission denied
@@ -924,9 +931,9 @@ class TemplateHelperDetailView(HomeAssistantView):
             )
 
         entry = hass.config_entries.async_get_entry(entry_id)
-        if entry is None or entry.domain != "template":
+        if entry is None or entry.domain not in CONFIG_ENTRY_HELPER_DOMAINS:
             return self.json_message(
-                f"Template helper '{entry_id}' not found",
+                f"Config entry helper '{entry_id}' not found",
                 HTTPStatus.NOT_FOUND,
                 ERR_HELPER_NOT_FOUND,
             )
@@ -947,28 +954,23 @@ class TemplateHelperDetailView(HomeAssistantView):
                 ERR_INVALID_CONFIG,
             )
 
+        # Remove empty string values that could cause enum validation errors
+        clean_updates = {
+            k: v for k, v in body.items() if v is not None and v != ""
+        }
+
         try:
-            result = await hass.config_entries.options.async_init(entry_id)
-            flow_id = result["flow_id"]
-
-            # Merge current options with updates
-            current_options = dict(entry.options)
-            update_data: dict[str, Any] = {}
-            for field in ("name", "state", "unit_of_measurement", "device_class",
-                          "state_class", "availability"):
-                if field in body:
-                    if body[field]:
-                        update_data[field] = body[field]
-                elif field in current_options:
-                    update_data[field] = current_options[field]
-
-            result = await hass.config_entries.options.async_configure(
-                flow_id, update_data
+            await _follow_options_flow(hass, entry_id, clean_updates)
+        except ValueError as err:
+            return self.json_message(
+                str(err),
+                HTTPStatus.BAD_REQUEST,
+                ERR_HELPER_INVALID_CONFIG,
             )
         except Exception as err:
-            _LOGGER.exception("Error updating template helper: %s", err)
+            _LOGGER.exception("Error updating config entry helper: %s", err)
             return self.json_message(
-                f"Error updating template helper: {err}",
+                f"Error updating helper: {err}",
                 HTTPStatus.BAD_REQUEST,
                 ERR_HELPER_INVALID_CONFIG,
             )
@@ -976,18 +978,18 @@ class TemplateHelperDetailView(HomeAssistantView):
         return self.json({
             "entry_id": entry_id,
             "title": entry.title,
-            "domain": "template",
-            "options": update_data,
-            "message": "Template helper updated",
+            "domain": entry.domain,
+            "updates": clean_updates,
+            "message": "Config entry helper updated",
         })
 
     async def delete(
         self, request: web.Request, entry_id: str
     ) -> web.Response:
-        """Handle DELETE request - delete a template helper.
+        """Handle DELETE request - delete a config entry helper.
 
         Returns:
-            204: Template helper deleted
+            204: Helper deleted
             401: Not authorized
             403: Permission denied
             404: Not found
@@ -1008,9 +1010,9 @@ class TemplateHelperDetailView(HomeAssistantView):
             )
 
         entry = hass.config_entries.async_get_entry(entry_id)
-        if entry is None or entry.domain != "template":
+        if entry is None or entry.domain not in CONFIG_ENTRY_HELPER_DOMAINS:
             return self.json_message(
-                f"Template helper '{entry_id}' not found",
+                f"Config entry helper '{entry_id}' not found",
                 HTTPStatus.NOT_FOUND,
                 ERR_HELPER_NOT_FOUND,
             )
@@ -1018,9 +1020,9 @@ class TemplateHelperDetailView(HomeAssistantView):
         try:
             await hass.config_entries.async_remove(entry_id)
         except Exception as err:
-            _LOGGER.exception("Error deleting template helper: %s", err)
+            _LOGGER.exception("Error deleting config entry helper: %s", err)
             return self.json_message(
-                f"Error deleting template helper: {err}",
+                f"Error deleting helper: {err}",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 

--- a/custom_components/config_mcp_test/views/helpers.py
+++ b/custom_components/config_mcp_test/views/helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from http import HTTPStatus
 from typing import Any
 
@@ -13,8 +12,11 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
+from homeassistant.helpers import entity_registry as er
+
 from ..const import (
     API_BASE_PATH_HELPERS,
+    API_BASE_PATH_TEMPLATE_HELPERS,
     CONF_HELPERS_CREATE,
     CONF_HELPERS_DELETE,
     CONF_HELPERS_READ,
@@ -30,8 +32,12 @@ from ..const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Storage version must match Home Assistant's internal version for these domains
+# Storage version for reading helpers via Store API (list/get operations)
 STORAGE_VERSION = 1
+
+# Key used by HA's collection.store_entity_registry_items() to store
+# StorageCollection instances in hass.data
+COLLECTION_INSTANCES_KEY = "collection_instances"
 
 
 def get_config_options(hass: HomeAssistant) -> dict[str, Any]:
@@ -54,23 +60,28 @@ def check_permission(hass: HomeAssistant, permission: str) -> bool:
     return options.get(permission, False)
 
 
-def _generate_helper_id(name: str) -> str:
-    """Generate a helper ID from the name.
+def _get_storage_collection(hass: HomeAssistant, domain: str) -> Any:
+    """Get Home Assistant's internal StorageCollection for a helper domain.
 
-    Args:
-        name: The helper name
-
-    Returns:
-        A valid helper ID
+    This accesses the same collection that HA's WebSocket commands
+    ({domain}/create, {domain}/update, {domain}/delete) use, ensuring
+    in-memory state and disk storage stay in sync.
     """
-    # Convert name to lowercase and replace spaces with underscores
-    helper_id = name.lower().replace(" ", "_")
-    # Remove any characters that aren't alphanumeric or underscores
-    helper_id = "".join(c for c in helper_id if c.isalnum() or c == "_")
-    # Ensure it doesn't start with a number
-    if helper_id and helper_id[0].isdigit():
-        helper_id = f"_{helper_id}"
-    return helper_id or f"helper_{uuid.uuid4().hex[:8]}"
+    instances = hass.data.get(COLLECTION_INSTANCES_KEY)
+    if instances is None:
+        raise ValueError(
+            f"No storage collections found in hass.data. "
+            f"Ensure the {domain} integration is loaded."
+        )
+
+    collection = instances.get(domain)
+    if collection is None:
+        raise ValueError(
+            f"No storage collection found for domain '{domain}'. "
+            f"Ensure the {domain} integration is loaded."
+        )
+
+    return collection
 
 
 async def _get_helpers_for_domain(hass: HomeAssistant, domain: str) -> list[dict[str, Any]]:
@@ -171,7 +182,10 @@ async def _create_helper(
     domain: str,
     config: dict[str, Any],
 ) -> dict[str, Any]:
-    """Create a new helper using the Store API.
+    """Create a new helper using HA's internal StorageCollection.
+
+    Uses the same collection that WebSocket commands ({domain}/create) use,
+    keeping in-memory state and .storage files in sync.
 
     Args:
         hass: Home Assistant instance
@@ -187,43 +201,26 @@ async def _create_helper(
     if domain not in HELPER_DOMAINS:
         raise ValueError(f"Invalid helper domain: {domain}")
 
-    # Use Store API to read/write .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
-    data = await store.async_load() or {"items": []}
+    collection = _get_storage_collection(hass, domain)
 
-    # Generate ID from name if not provided
-    helper_id = config.get("id") or _generate_helper_id(config["name"])
+    # Remove 'id' if present — the collection generates IDs automatically
+    create_data = {k: v for k, v in config.items() if k != "id"}
 
-    # Check for duplicate ID
-    existing_ids = {item.get("id") for item in data.get("items", [])}
-    if helper_id in existing_ids:
-        raise ValueError(f"Helper with ID '{helper_id}' already exists")
-
-    # Build the helper configuration
-    new_helper = {
-        "id": helper_id,
-        **config,
-    }
-
-    # Add to items list
-    if "items" not in data:
-        data["items"] = []
-    data["items"].append(new_helper)
-
-    # Save to storage
-    await store.async_save(data)
-
-    # Reload the domain to pick up the new helper
     try:
-        await hass.services.async_call(domain, "reload", blocking=True)
-    except Exception as err:
-        _LOGGER.warning("Failed to reload %s after creation: %s", domain, err)
+        item = await collection.async_create_item(create_data)
+    except ValueError as err:
+        raise ValueError(f"Failed to create helper: {err}") from err
+
+    if hasattr(item, "as_dict"):
+        item_data = item.as_dict()
+    elif isinstance(item, dict):
+        item_data = item
+    else:
+        item_data = {"id": str(item)}
 
     return {
-        "id": helper_id,
-        "name": config.get("name"),
         "domain": domain,
-        **{k: v for k, v in new_helper.items() if k not in ("id", "name")},
+        **item_data,
     }
 
 
@@ -233,7 +230,10 @@ async def _update_helper(
     helper_id: str,
     updates: dict[str, Any],
 ) -> dict[str, Any]:
-    """Update an existing helper using the Store API.
+    """Update an existing helper using HA's internal StorageCollection.
+
+    Uses the same collection that WebSocket commands ({domain}/update) use,
+    keeping in-memory state and .storage files in sync.
 
     Args:
         hass: Home Assistant instance
@@ -247,42 +247,28 @@ async def _update_helper(
     Raises:
         ValueError: If update fails
     """
-    # Use Store API to read/write .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
-    data = await store.async_load()
+    collection = _get_storage_collection(hass, domain)
 
-    if data is None:
-        raise ValueError(f"Helper domain {domain} has no stored data")
+    # Remove 'id' and 'domain' from updates — these can't be changed
+    update_data = {k: v for k, v in updates.items() if k not in ("id", "domain")}
 
-    items = data.get("items", [])
-
-    # Find and update the helper
-    updated_item = None
-    for i, item in enumerate(items):
-        if isinstance(item, dict) and item.get("id") == helper_id:
-            # Merge updates with existing item (don't change id)
-            items[i] = {**item, **updates, "id": helper_id}
-            updated_item = items[i]
-            break
-
-    if updated_item is None:
-        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
-
-    # Save to storage
-    data["items"] = items
-    await store.async_save(data)
-
-    # Reload the domain to pick up the changes
     try:
-        await hass.services.async_call(domain, "reload", blocking=True)
-    except Exception as err:
-        _LOGGER.warning("Failed to reload %s after update: %s", domain, err)
+        item = await collection.async_update_item(helper_id, update_data)
+    except KeyError:
+        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
+    except ValueError as err:
+        raise ValueError(f"Failed to update helper: {err}") from err
+
+    if hasattr(item, "as_dict"):
+        item_data = item.as_dict()
+    elif isinstance(item, dict):
+        item_data = item
+    else:
+        item_data = {"id": helper_id}
 
     return {
-        "id": updated_item.get("id"),
-        "name": updated_item.get("name"),
         "domain": domain,
-        **{k: v for k, v in updated_item.items() if k not in ("id", "name")},
+        **item_data,
     }
 
 
@@ -291,7 +277,10 @@ async def _delete_helper(
     domain: str,
     helper_id: str,
 ) -> None:
-    """Delete a helper using the Store API.
+    """Delete a helper using HA's internal StorageCollection.
+
+    Uses the same collection that WebSocket commands ({domain}/delete) use,
+    keeping in-memory state and .storage files in sync.
 
     Args:
         hass: Home Assistant instance
@@ -301,31 +290,12 @@ async def _delete_helper(
     Raises:
         ValueError: If deletion fails
     """
-    # Use Store API to read/write .storage/core.{domain}
-    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"core.{domain}")
-    data = await store.async_load()
+    collection = _get_storage_collection(hass, domain)
 
-    if data is None:
-        raise ValueError(f"Helper domain {domain} has no stored data")
-
-    items = data.get("items", [])
-
-    # Find and remove the helper
-    original_count = len(items)
-    items = [item for item in items if not (isinstance(item, dict) and item.get("id") == helper_id)]
-
-    if len(items) == original_count:
-        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
-
-    # Save to storage
-    data["items"] = items
-    await store.async_save(data)
-
-    # Reload the domain to pick up the changes
     try:
-        await hass.services.async_call(domain, "reload", blocking=True)
-    except Exception as err:
-        _LOGGER.warning("Failed to reload %s after deletion: %s", domain, err)
+        await collection.async_delete_item(helper_id)
+    except KeyError:
+        raise ValueError(f"Helper '{helper_id}' not found in {domain}")
 
 
 class HelperListView(HomeAssistantView):
@@ -675,6 +645,382 @@ class HelperDetailView(HomeAssistantView):
             _LOGGER.exception("Error deleting helper: %s", err)
             return self.json_message(
                 f"Error deleting helper: {err}",
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+
+        return web.Response(status=HTTPStatus.NO_CONTENT)
+
+
+# Template sub-types available for creation
+TEMPLATE_TYPES = [
+    "alarm_control_panel", "binary_sensor", "button", "cover",
+    "event", "fan", "image", "light", "lock", "number",
+    "select", "sensor", "switch", "update", "vacuum", "weather",
+]
+
+
+class TemplateHelperListView(HomeAssistantView):
+    """View to list and create template-based helpers."""
+
+    url = API_BASE_PATH_TEMPLATE_HELPERS
+    name = "api:config_mcp:template_helpers"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Handle GET request - list all template helpers.
+
+        Query params:
+            template_type: Optional filter (e.g., 'sensor', 'binary_sensor')
+
+        Returns:
+            200: JSON array of template helper data
+            403: Permission denied
+        """
+        hass: HomeAssistant = request.app["hass"]
+
+        if not check_permission(hass, CONF_HELPERS_READ):
+            return self.json_message(
+                "Helper read permission is disabled",
+                HTTPStatus.FORBIDDEN,
+            )
+
+        type_filter = request.query.get("template_type")
+        entries = hass.config_entries.async_entries("template")
+
+        results = []
+        for entry in entries:
+            template_type = entry.options.get("template_type", "")
+            if type_filter and template_type != type_filter:
+                continue
+
+            results.append({
+                "entry_id": entry.entry_id,
+                "title": entry.title,
+                "domain": "template",
+                "template_type": template_type,
+                "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
+                "options": dict(entry.options),
+            })
+
+        results.sort(key=lambda x: (x.get("template_type", ""), x.get("title", "").lower()))
+        return self.json(results)
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Handle POST request - create a template helper.
+
+        Request body:
+            {
+                "template_type": "sensor",  (required)
+                "name": "My Sensor",  (required)
+                "state": "{{ states('sensor.x') }}",  (required)
+                "unit_of_measurement": "°C",  (optional)
+                "device_class": "temperature",  (optional, omit if not set)
+                "state_class": "measurement",  (optional, omit if not set)
+                "availability": "{{ true }}",  (optional)
+            }
+
+        Returns:
+            201: Template helper created
+            400: Invalid request
+            401: Not authorized
+            403: Permission denied
+        """
+        hass: HomeAssistant = request.app["hass"]
+
+        if not check_permission(hass, CONF_HELPERS_CREATE):
+            return self.json_message(
+                "Helper create permission is disabled",
+                HTTPStatus.FORBIDDEN,
+            )
+
+        user = request.get("hass_user")
+        if user is None or not user.is_admin:
+            return self.json_message(
+                "Admin permission required",
+                HTTPStatus.UNAUTHORIZED,
+            )
+
+        try:
+            body = await request.json()
+        except ValueError:
+            return self.json_message(
+                "Invalid JSON in request body",
+                HTTPStatus.BAD_REQUEST,
+                ERR_INVALID_CONFIG,
+            )
+
+        template_type = body.get("template_type")
+        name = body.get("name")
+        state = body.get("state")
+
+        if not template_type:
+            return self.json_message(
+                "Missing required field: template_type",
+                HTTPStatus.BAD_REQUEST,
+                ERR_HELPER_INVALID_CONFIG,
+            )
+
+        if not name:
+            return self.json_message(
+                "Missing required field: name",
+                HTTPStatus.BAD_REQUEST,
+                ERR_HELPER_INVALID_CONFIG,
+            )
+
+        if not state:
+            return self.json_message(
+                "Missing required field: state",
+                HTTPStatus.BAD_REQUEST,
+                ERR_HELPER_INVALID_CONFIG,
+            )
+
+        try:
+            # Step 1: Initiate config entry flow
+            result = await hass.config_entries.flow.async_init(
+                "template", context={"source": "user"}
+            )
+            flow_id = result["flow_id"]
+
+            # Step 2: Select template sub-type
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, {"next_step_id": template_type}
+            )
+
+            # Step 3: Submit configuration
+            config_data: dict[str, Any] = {"name": name, "state": state}
+            for field in ("unit_of_measurement", "device_class", "state_class",
+                          "availability", "device_id"):
+                if field in body and body[field]:
+                    config_data[field] = body[field]
+
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, config_data
+            )
+        except Exception as err:
+            _LOGGER.exception("Error creating template helper: %s", err)
+            return self.json_message(
+                f"Error creating template helper: {err}",
+                HTTPStatus.BAD_REQUEST,
+                ERR_HELPER_INVALID_CONFIG,
+            )
+
+        if result.get("type") != "create_entry":
+            return self.json_message(
+                f"Unexpected flow result: {result.get('type')}",
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+
+        entry_result = result.get("result", {})
+        entry_id = (
+            entry_result.entry_id
+            if hasattr(entry_result, "entry_id")
+            else entry_result.get("entry_id")
+        )
+
+        return self.json(
+            {
+                "entry_id": entry_id,
+                "title": result.get("title", name),
+                "domain": "template",
+                "template_type": template_type,
+                "options": result.get("options", config_data),
+                "message": "Template helper created",
+            },
+            HTTPStatus.CREATED,
+        )
+
+
+class TemplateHelperDetailView(HomeAssistantView):
+    """View for single template helper operations."""
+
+    url = API_BASE_PATH_TEMPLATE_HELPERS + "/{entry_id}"
+    name = "api:config_mcp:template_helper"
+    requires_auth = True
+
+    async def get(
+        self, request: web.Request, entry_id: str
+    ) -> web.Response:
+        """Handle GET request - get a single template helper.
+
+        Returns:
+            200: Template helper data with entities
+            403: Permission denied
+            404: Not found
+        """
+        hass: HomeAssistant = request.app["hass"]
+
+        if not check_permission(hass, CONF_HELPERS_READ):
+            return self.json_message(
+                "Helper read permission is disabled",
+                HTTPStatus.FORBIDDEN,
+            )
+
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != "template":
+            return self.json_message(
+                f"Template helper '{entry_id}' not found",
+                HTTPStatus.NOT_FOUND,
+                ERR_HELPER_NOT_FOUND,
+            )
+
+        result: dict[str, Any] = {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "domain": "template",
+            "template_type": entry.options.get("template_type", ""),
+            "state": entry.state.value if hasattr(entry.state, "value") else str(entry.state),
+            "supports_options": entry.supports_options,
+            "options": dict(entry.options),
+        }
+
+        # Include associated entities with current state
+        entity_registry = er.async_get(hass)
+        entities = er.async_entries_for_config_entry(entity_registry, entry_id)
+        if entities:
+            entity_entries = []
+            for entity_entry in entities:
+                entity_data: dict[str, Any] = {
+                    "entity_id": entity_entry.entity_id,
+                    "name": entity_entry.name or entity_entry.original_name,
+                    "area_id": entity_entry.area_id,
+                    "disabled": entity_entry.disabled_by is not None,
+                }
+                state = hass.states.get(entity_entry.entity_id)
+                if state:
+                    entity_data["current_state"] = {
+                        "state": state.state,
+                        "attributes": dict(state.attributes),
+                    }
+                entity_entries.append(entity_data)
+            result["entities"] = entity_entries
+
+        return self.json(result)
+
+    async def patch(
+        self, request: web.Request, entry_id: str
+    ) -> web.Response:
+        """Handle PATCH request - update a template helper via options flow.
+
+        Returns:
+            200: Template helper updated
+            400: Invalid request
+            401: Not authorized
+            403: Permission denied
+            404: Not found
+        """
+        hass: HomeAssistant = request.app["hass"]
+
+        if not check_permission(hass, CONF_HELPERS_UPDATE):
+            return self.json_message(
+                "Helper update permission is disabled",
+                HTTPStatus.FORBIDDEN,
+            )
+
+        user = request.get("hass_user")
+        if user is None or not user.is_admin:
+            return self.json_message(
+                "Admin permission required",
+                HTTPStatus.UNAUTHORIZED,
+            )
+
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != "template":
+            return self.json_message(
+                f"Template helper '{entry_id}' not found",
+                HTTPStatus.NOT_FOUND,
+                ERR_HELPER_NOT_FOUND,
+            )
+
+        try:
+            body = await request.json()
+        except ValueError:
+            return self.json_message(
+                "Invalid JSON in request body",
+                HTTPStatus.BAD_REQUEST,
+                ERR_INVALID_CONFIG,
+            )
+
+        if not body:
+            return self.json_message(
+                "No updates provided",
+                HTTPStatus.BAD_REQUEST,
+                ERR_INVALID_CONFIG,
+            )
+
+        try:
+            result = await hass.config_entries.options.async_init(entry_id)
+            flow_id = result["flow_id"]
+
+            # Merge current options with updates
+            current_options = dict(entry.options)
+            update_data: dict[str, Any] = {}
+            for field in ("name", "state", "unit_of_measurement", "device_class",
+                          "state_class", "availability"):
+                if field in body:
+                    if body[field]:
+                        update_data[field] = body[field]
+                elif field in current_options:
+                    update_data[field] = current_options[field]
+
+            result = await hass.config_entries.options.async_configure(
+                flow_id, update_data
+            )
+        except Exception as err:
+            _LOGGER.exception("Error updating template helper: %s", err)
+            return self.json_message(
+                f"Error updating template helper: {err}",
+                HTTPStatus.BAD_REQUEST,
+                ERR_HELPER_INVALID_CONFIG,
+            )
+
+        return self.json({
+            "entry_id": entry_id,
+            "title": entry.title,
+            "domain": "template",
+            "options": update_data,
+            "message": "Template helper updated",
+        })
+
+    async def delete(
+        self, request: web.Request, entry_id: str
+    ) -> web.Response:
+        """Handle DELETE request - delete a template helper.
+
+        Returns:
+            204: Template helper deleted
+            401: Not authorized
+            403: Permission denied
+            404: Not found
+        """
+        hass: HomeAssistant = request.app["hass"]
+
+        if not check_permission(hass, CONF_HELPERS_DELETE):
+            return self.json_message(
+                "Helper delete permission is disabled",
+                HTTPStatus.FORBIDDEN,
+            )
+
+        user = request.get("hass_user")
+        if user is None or not user.is_admin:
+            return self.json_message(
+                "Admin permission required",
+                HTTPStatus.UNAUTHORIZED,
+            )
+
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != "template":
+            return self.json_message(
+                f"Template helper '{entry_id}' not found",
+                HTTPStatus.NOT_FOUND,
+                ERR_HELPER_NOT_FOUND,
+            )
+
+        try:
+            await hass.config_entries.async_remove(entry_id)
+        except Exception as err:
+            _LOGGER.exception("Error deleting template helper: %s", err)
+            return self.json_message(
+                f"Error deleting template helper: {err}",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 


### PR DESCRIPTION
## Summary

- **Fix BUG 3 (Store API cache bypass)**: Replace Store API with HA's internal `StorageCollection` for helper CRUD, keeping in-memory state and `.storage` files in sync immediately
- **Complete StorageCollection helper coverage**: 9 types — `input_boolean`, `input_button`, `input_number`, `input_text`, `input_select`, `input_datetime`, `counter`, `timer`, `schedule`
- **Config Entry Flow helper support**: 5 new MCP tools supporting all 17 config-entry-flow helper domains with a generic flow follower that handles direct, multi-step, and menu-based flows automatically
- **REST API views**: `ConfigEntryHelperListView` and `ConfigEntryHelperDetailView` at `/api/config_mcp/config_entry_helpers`

## New MCP Tools

### StorageCollection (9 domains)
| Tool | Description |
|------|-------------|
| `ha_list_helpers` | List helpers with optional domain filter |
| `ha_get_helper` | Get helper by `entity_id` |
| `ha_create_helper` | Create helper with flat params |
| `ha_update_helper` | Update helper fields |
| `ha_delete_helper` | Delete helper by `entity_id` |

### Config Entry Flow (17 domains)
| Tool | Description |
|------|-------------|
| `ha_list_config_entry_helpers` | List with optional `domain`/`sub_type` filter |
| `ha_get_config_entry_helper` | Get by `entry_id`, returns options + entities |
| `ha_create_config_entry_helper` | Create via config entry flow (supports `sub_type` for menu-flow domains) |
| `ha_update_config_entry_helper` | Update via options flow, merges with existing options |
| `ha_delete_config_entry_helper` | Delete config entry |

Supported domains: `derivative`, `filter`, `generic_hygrostat`, `generic_thermostat`, `group`, `history_stats`, `integration`, `min_max`, `mold_indicator`, `random`, `statistics`, `switch_as_x`, `template`, `threshold`, `tod`, `trend`, `utility_meter`

Menu-flow domains requiring `sub_type`: `group`, `template`, `random`

## Architecture

### StorageCollection access (HA 2026.x)
Helper integrations do **not** store collections in `hass.data["collection_instances"]` in current HA. Instead they register WebSocket handlers via `DictStorageCollectionWebsocket`. The collection is accessed by unwrapping the registered handler:

```python
ws_handlers = hass.data["websocket_api"]
handler = ws_handlers[f"{domain}/create"][0]
# Unwrap @require_admin / @async_response decorators
while hasattr(handler, "__wrapped__"):
    handler = handler.__wrapped__
collection = handler.__self__.storage_collection
```

List/get operations read from `collection.data` (in-memory, reflects changes immediately) with a fallback to the `.storage/{domain}` file on disk.

### Config Entry Flow helpers
Uses `hass.config_entries.flow` for creation and `hass.config_entries.options` for updates. A generic `_follow_config_flow()` function dynamically inspects each step's voluptuous schema and submits matching fields, handling three flow patterns:
- **Direct form** — single-step (e.g., `threshold`, `derivative`)
- **Multi-step** — sequential steps, each with a different schema subset
- **Menu-first** — sub-type selection then form (e.g., `template/sensor`, `group/light`)

## Testing
Tested on HA 2026.3.1. Full CRUD verified for:
- `input_boolean` (StorageCollection)
- `threshold` (Config Entry, direct flow)
- `template/sensor` (Config Entry, menu flow)
- `group/light` (Config Entry, menu flow)